### PR TITLE
Added basic auth using the `basic-auth-parser` library

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,20 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-e` or `--ext` Default file extension (defaults to 'html')
 
+`--user` User name for basic authentication
+
+`--pass` Password for basic authentication
+
 `-s` or `--silent` In silent mode, log messages aren't logged to the console.
 
 `-h` or `--help` Displays a list of commands and exits.
 
 `-c` Set cache time (in seconds) for cache-control max-age header, e.g. -c10 for 10 seconds. To disable caching, use -c-1.
+
+### Authenication
+
+**Warning**: please note that your user name and password are sent as plain
+text because `http-server` does not currently support HTTPS. Therefore we
+recommend you use a unique, one-time password each time you run the server. The
+feature is **not** intended for real security.
+

--- a/README.md
+++ b/README.md
@@ -54,17 +54,19 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-i` Display autoIndex (defaults to 'True')
 
+`-c` Set cache time (in seconds) for cache-control max-age header, e.g. -c10 for 10 seconds. To disable caching, use -c-1.
+
 `-e` or `--ext` Default file extension (defaults to 'html')
-
-`--user` User name for basic authentication
-
-`--pass` Password for basic authentication
 
 `-s` or `--silent` In silent mode, log messages aren't logged to the console.
 
 `-h` or `--help` Displays a list of commands and exits.
 
-`-c` Set cache time (in seconds) for cache-control max-age header, e.g. -c10 for 10 seconds. To disable caching, use -c-1.
+`--user` User name for basic authentication
+
+`--pass` Password for basic authentication
+
+`--cors` Enable CORS via the `Access-Control-Allow-Origin` header
 
 ### Authenication
 

--- a/bin/http-server
+++ b/bin/http-server
@@ -15,6 +15,8 @@ if (argv.h || argv.help) {
     "  -d                 Show directory listings [true]",
     "  -i                 Display autoIndex [true]",
     "  -e --ext           Default file extension if none supplied [none]",
+    "  --user             User name for basic authenication [none]",
+    "  --pass             Password for basic authenication [none]",
     "  -s --silent        Suppress log messages from output",
     "  -h --help          Print this list and exit.",
     "  -c                 Set cache time (in seconds). e.g. -c10 for 10 seconds.",
@@ -43,7 +45,9 @@ function listen(port) {
     cache: argv.c,
     showDir: argv.d,
     autoIndex: argv.i,
-    ext: argv.e || argv.ext
+    ext: argv.e || argv.ext,
+    user: argv.user,
+    pass: argv.pass
   });
 
   server.listen(port, host, function() {

--- a/bin/http-server
+++ b/bin/http-server
@@ -15,15 +15,15 @@ if (argv.h || argv.help) {
     "  -a                 Address to use [0.0.0.0]",
     "  -d                 Show directory listings [true]",
     "  -i                 Display autoIndex [true]",
-    "  -e --ext           Default file extension if none supplied [none]",
-    "  --user             User name for basic authenication [none]",
-    "  --pass             Password for basic authenication [none]",
-    "  -s --silent        Suppress log messages from output",
-    "  --cors             Enable CORS via the 'Access-Control-Allow-Origin' header",
     "  -o                 Open browser window after staring the server",
     "  -c                 Set cache time (in seconds). e.g. -c10 for 10 seconds.",
     "                     To disable caching, use -c-1.",
-    "  -h --help          Print this list and exit."
+    "  -e --ext           Default file extension if none supplied [none]",
+    "  -s --silent        Suppress log messages from output",
+    "  -h --help          Print this list and exit.",
+    "  --user             User name for basic authenication [none]",
+    "  --pass             Password for basic authenication [none]",
+    "  --cors             Enable CORS via the 'Access-Control-Allow-Origin' header"
   ].join('\n'));
   process.exit();
 }

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -1,10 +1,12 @@
 var fs = require('fs'),
     util = require('util'),
     union = require('union'),
-    ecstatic = require('ecstatic');
+    ecstatic = require('ecstatic'),
+    auth = require('http-auth');
 
 var HTTPServer = exports.HTTPServer = function (options) {
   options = options || {};
+  var that = this;
 
   if (options.root) {
     this.root = options.root;
@@ -18,14 +20,31 @@ var HTTPServer = exports.HTTPServer = function (options) {
       this.root = './';
     }
   }
-  
+
   if (options.headers) {
-    this.headers = options.headers; 
+    this.headers = options.headers;
   }
 
   this.cache = options.cache || 3600; // in seconds.
   this.showDir = options.showDir !== 'false';
   this.autoIndex = options.autoIndex !== 'false';
+  this.user = options.user || '';
+  this.pass = options.pass || '';
+
+  this.before = []; // The middleware to run before the static server
+
+  // Setup basic auth if specified
+  if (this.user || this.pass) {
+    var basic = auth.basic({
+        realm: 'Please log in.'
+      }, function(user, pass, cb) {
+        var isAuthenticated = (user === that.user && pass === that.pass);
+        cb(isAuthenticated);
+      }
+    );
+
+    this.before.push(auth.connect(basic)); // use connect style middleware with `union`
+  }
 
   if (options.ext) {
     this.ext = options.ext === true
@@ -34,7 +53,7 @@ var HTTPServer = exports.HTTPServer = function (options) {
   }
 
   this.server = union.createServer({
-    before: (options.before || []).concat([
+    before: this.before.concat([
       ecstatic({
         root: this.root,
         cache: this.cache,

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -2,7 +2,7 @@ var fs = require('fs'),
     util = require('util'),
     union = require('union'),
     ecstatic = require('ecstatic'),
-    auth = require('http-auth');
+    auth = require('basic-auth-parser');
 
 var HTTPServer = exports.HTTPServer = function (options) {
   options = options || {};
@@ -33,17 +33,27 @@ var HTTPServer = exports.HTTPServer = function (options) {
 
   this.before = []; // The middleware to run before the static server
 
+  // Add logging middleware
+  this.before.push(
+    function (req, res) {
+      options.logFn && options.logFn(req, res);
+      res.emit('next');
+  });
+
   // Setup basic auth if specified
   if (this.user || this.pass) {
-    var basic = auth.basic({
-        realm: 'Please log in.'
-      }, function(user, pass, cb) {
-        var isAuthenticated = (user === that.user && pass === that.pass);
-        cb(isAuthenticated);
-      }
-    );
+    this.before.push(function (req, res) {
+      var parsedAuth = auth(req.headers['authorization']);
 
-    this.before.push(auth.connect(basic)); // use connect style middleware with `union`
+      if (parsedAuth.username === that.user
+          && parsedAuth.password === that.pass) {
+        res.emit('next');
+      } else {
+        res.setHeader('WWW-Authenticate', 'Basic realm="please authenicate"');
+        res.writeHead(401);
+        res.end('401 Unauthenticated');
+      }
+    });
   }
 
   if (options.ext) {
@@ -52,12 +62,9 @@ var HTTPServer = exports.HTTPServer = function (options) {
       : options.ext;
   }
 
+
   this.server = union.createServer({
     before: (this.before || []).concat([
-      function (req, res) {
-        options.logFn && options.logFn(req, res);
-        res.emit('next');
-      },
       ecstatic({
         root: this.root,
         cache: this.cache,

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -43,9 +43,14 @@ var HTTPServer = exports.HTTPServer = function (options) {
   // Setup basic auth if specified
   if (this.user || this.pass) {
     this.before.push(function (req, res) {
-      var parsedAuth = auth(req.headers['authorization']);
+      var header = req.headers['authorization'],
+          parsedAuth;
 
-      if (parsedAuth.username === that.user
+      if (header)
+        parsedAuth = auth(req.headers['authorization']);
+
+      if (parsedAuth
+          && parsedAuth.username === that.user
           && parsedAuth.password === that.pass) {
         res.emit('next');
       } else {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "optimist": "0.5.x",
     "union": "0.3.x",
     "ecstatic": "0.4.x",
-    "portfinder": "0.2.x"
+    "portfinder": "0.2.x",
+    "http-auth": "~2.0.9"
   },
   "devDependencies": {
     "vows": "0.7.x",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "union": "0.3.x",
     "ecstatic": "0.4.x",
     "portfinder": "0.2.x",
-    "http-auth": "~2.0.9",
-    "opener": "~1.3.0"
+    "opener": "~1.3.0",
+    "basic-auth-parser": "0.0.2"
   },
   "devDependencies": {
     "vows": "0.7.x",

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -28,7 +28,7 @@ vows.describe('http-server').addBatch({
           auth: {
             'user': 'bert',
             'pass': 'bertington',
-            'sendImmediately': false
+            'sendImmediately': true
           }
         }, this.callback);
       },

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -8,6 +8,46 @@ var assert = require('assert'),
 var root = path.join(__dirname, 'fixtures', 'root');
 
 vows.describe('http-server').addBatch({
+  'When http-server is listening on 8081 with username "bert" and password "bertington"': {
+    topic: function () {
+      var server = httpServer.createServer({
+        root: root,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Credentials': 'true'
+        },
+        user: 'bert',
+        pass: 'bertington'
+      });
+      server.listen(8081);
+      this.callback(null, server);
+    },
+    'it should serve files from root directory': {
+      topic: function () {
+        request.get('http://127.0.0.1:8081/file', {
+          auth: {
+            'user': 'bert',
+            'pass': 'bertington',
+            'sendImmediately': false
+          }
+        }, this.callback);
+      },
+      'status code should be 200': function (res) {
+        assert.equal(res.statusCode, 200);
+      },
+      'and file content': {
+        topic: function (res, body) {
+          var self = this;
+          fs.readFile(path.join(root, 'file'), 'utf8', function (err, data) {
+            self.callback(err, data, body);
+          });
+        },
+        'should match content of served file': function (err, file, body) {
+          assert.equal(body.trim(), file.trim());
+        }
+      }
+    }
+  },
   'When http-server is listening on 8080': {
     topic: function () {
       var server = httpServer.createServer({


### PR DESCRIPTION
I first merged all the upstream changes and resolved conflicts. Then I used the `basic-auth-parser` library to cleanly implement basic auth. Tests pass.