### PR TITLE
Add option to dynamically serve a /robots.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-s` or `--silent` In silent mode, log messages aren't logged to the console.
 
+`-r` or `--robots` Provide a /robots.txt (whose content defaults to 'User-agent: *\nDisallow: /')
+
 `-h` or `--help` Displays a list of commands and exits.
 
 `-c` Set cache time (in seconds) for cache-control max-age header, e.g. -c10 for 10 seconds. To disable caching, use -c-1.

--- a/bin/http-server
+++ b/bin/http-server
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-var colors = require('colors'),
+var colors     = require('colors'),
     httpServer = require('../lib/http-server'),
-    argv = require('optimist').argv,
+    argv       = require('optimist').argv,
     portfinder = require('portfinder'),
-    opener = require('opener');
+    opener     = require('opener');
 
 if (argv.h || argv.help) {
   console.log([
@@ -21,6 +21,7 @@ if (argv.h || argv.help) {
     "  -o                 Open browser window after staring the server",
     "  -c                 Set cache time (in seconds). e.g. -c10 for 10 seconds.",
     "                     To disable caching, use -c-1.",
+	"  -r --robots        Respond to /robots.txt [User-agent: *\\nDisallow: /]",
     "  -h --help          Print this list and exit."
   ].join('\n'));
   process.exit();
@@ -53,6 +54,7 @@ function listen(port) {
     cache: argv.c,
     showDir: argv.d,
     autoIndex: argv.i,
+	robots: argv.r || argv.robots,
     ext: argv.e || argv.ext,
     logFn: requestLogger
   };

--- a/bin/http-server
+++ b/bin/http-server
@@ -21,7 +21,7 @@ if (argv.h || argv.help) {
     "  -o                 Open browser window after staring the server",
     "  -c                 Set cache time (in seconds). e.g. -c10 for 10 seconds.",
     "                     To disable caching, use -c-1.",
-	"  -r --robots        Respond to /robots.txt [User-agent: *\\nDisallow: /]",
+    "  -r --robots        Respond to /robots.txt [User-agent: *\\nDisallow: /]",
     "  -h --help          Print this list and exit."
   ].join('\n'));
   process.exit();
@@ -54,7 +54,7 @@ function listen(port) {
     cache: argv.c,
     showDir: argv.d,
     autoIndex: argv.i,
-	robots: argv.r || argv.robots,
+    robots: argv.r || argv.robots,
     ext: argv.e || argv.ext,
     logFn: requestLogger
   };

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -39,6 +39,15 @@ var HTTPServer = exports.HTTPServer = function (options) {
         options.logFn && options.logFn(req, res);
         res.emit('next');
       },
+      function (req,res){
+        if (options.robots && '/robots.txt' == req.url) {
+          res.setHeader('Content-Type', 'text/plain');
+		  var robots = options.robots === true ? "User-agent: *\nDisallow: /" : options.robots.replace(/\\n/,"\n");
+          res.end(robots);
+        } else {
+          res.emit('next');
+        }
+      },
       ecstatic({
         root: this.root,
         cache: this.cache,

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -42,7 +42,7 @@ var HTTPServer = exports.HTTPServer = function (options) {
       function (req,res){
         if (options.robots && '/robots.txt' == req.url) {
           res.setHeader('Content-Type', 'text/plain');
-		  var robots = options.robots === true ? "User-agent: *\nDisallow: /" : options.robots.replace(/\\n/,"\n");
+          var robots = options.robots === true ? "User-agent: *\nDisallow: /" : options.robots.replace(/\\n/,"\n");
           res.end(robots);
         } else {
           res.emit('next');

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -15,7 +15,8 @@ vows.describe('http-server').addBatch({
         headers: {
           'Access-Control-Allow-Origin': '*',
           'Access-Control-Allow-Credentials': 'true'
-        }
+        },
+		robots : true,
       });
       server.listen(8080);
       this.callback(null, server);
@@ -57,6 +58,14 @@ vows.describe('http-server').addBatch({
         assert.include(body, '/canYouSeeMe');
       }
     },
+	'when robots options is activated' :{
+		topic: function () {
+			request('http://127.0.0.1:8080/', this.callback);
+		},
+		'should respond with status code 200 to /robots.txt' : function (res){
+			assert.equal(res.statusCode, 200);
+		}
+	},
     'and options include custom set http-headers': {
       topic: function () {
         request('http://127.0.0.1:8080/', this.callback);

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -16,7 +16,7 @@ vows.describe('http-server').addBatch({
           'Access-Control-Allow-Origin': '*',
           'Access-Control-Allow-Credentials': 'true'
         },
-		robots : true,
+        robots : true,
       });
       server.listen(8080);
       this.callback(null, server);
@@ -58,14 +58,14 @@ vows.describe('http-server').addBatch({
         assert.include(body, '/canYouSeeMe');
       }
     },
-	'when robots options is activated' :{
-		topic: function () {
-			request('http://127.0.0.1:8080/', this.callback);
-		},
-		'should respond with status code 200 to /robots.txt' : function (res){
-			assert.equal(res.statusCode, 200);
-		}
-	},
+    'when robots options is activated' :{
+      topic: function () {
+        request('http://127.0.0.1:8080/', this.callback);
+      },
+      'should respond with status code 200 to /robots.txt' : function (res){
+        assert.equal(res.statusCode, 200);
+      }
+    },
     'and options include custom set http-headers': {
       topic: function () {
         request('http://127.0.0.1:8080/', this.callback);


### PR DESCRIPTION
I added a --robots or -r option to dynamically respond to /robots.txt. This allows you to expose you http-server instance without the risk of having your folders indexed by a search engine crawler.
