### PR TITLE
accept command line arg for a custom header

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,6 @@ This will install `http-server` globally so that it may be run from the command 
 `-h` or `--help` Displays a list of commands and exits.
 
 `-c` Set cache time (in seconds) for cache-control max-age header, e.g. -c10 for 10 seconds. To disable caching, use -c-1.
+
+`-H` or `--header` Send the specified header with responses, e.g.
+`-H "Strict-Transport-Security: max-age=315360000; includeSubdomains"`.

--- a/bin/http-server
+++ b/bin/http-server
@@ -21,6 +21,8 @@ if (argv.h || argv.help) {
     "  -o                 Open browser window after staring the server",
     "  -c                 Set cache time (in seconds). e.g. -c10 for 10 seconds.",
     "                     To disable caching, use -c-1.",
+    "  -H --header        Send the specified header with responses,",
+    "                     e.g. -H 'X-MY-HEADER: foo'",
     "  -h --help          Print this list and exit."
   ].join('\n'));
   process.exit();
@@ -47,6 +49,14 @@ if (!port) {
   listen(port);
 }
 
+function addHeader(headers, header) {
+  if (!header || !header.indexOf) return;
+  var idx = header.indexOf(':'),
+      key = header.substring(0, idx),
+      val = header.substring(idx + 1).trim();
+  headers[key] = val;
+}
+
 function listen(port) {
   var options = {
     root: argv._[0],
@@ -54,12 +64,15 @@ function listen(port) {
     showDir: argv.d,
     autoIndex: argv.i,
     ext: argv.e || argv.ext,
+    headers: {},
     logFn: requestLogger
   };
 
   if (argv.cors) {
-    options.headers = { 'Access-Control-Allow-Origin': '*' };
+    options.headers['Access-Control-Allow-Origin'] = '*';
   }
+
+  addHeader(options.headers, argv.H || argv.header);
 
   var server = httpServer.createServer(options);
   server.listen(port, host, function() {


### PR DESCRIPTION
This builds on @luk-'s work in #28 to allow specifying a custom header via the -H or --header command line argument.

A future change could allow for specifying more than one custom header via a --headers command line argument. It looks like optimist does not support recovering multiple passed-in -H arguments, so unfortunately emulating curl isn't an option (e.g. `curl -H 'X-Foo: Bar' -H 'X-Baz: Qux' http://www.google.com/`).

For now, this is definitely useful for e.g. adding an [HSTS header](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security), so I thought I'd send a pull request.