### PR TITLE
Allow for non-default browsers with optional path argument

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -20,7 +20,7 @@ if (argv.h || argv.help) {
     "  -e --ext           Default file extension if none supplied [none]",
     "  -s --silent        Suppress log messages from output",
     "  --cors             Enable CORS via the 'Access-Control-Allow-Origin' header",
-    "  -o                 Open browser window after starting the server",
+    "  -o [path]          Open browser window after starting the server",
     "  -c                 Set cache time (in seconds). e.g. -c10 for 10 seconds.",
     "                     To disable caching, use -c-1.",
     "",
@@ -90,7 +90,8 @@ function listen(port) {
 
     log('Hit CTRL-C to stop the server');
     if (argv.o) {
-      opener(uri);
+      var application = argv.o !== true ? argv.o : null;
+      opener(uri, {command: application});
     }
   });
 }


### PR DESCRIPTION
Example: 
```bash
http-server -p 9999 -o /Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary
```