### PR TITLE
Added logging for errors (e.g. 404 - file not found)

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -40,9 +40,14 @@ var port = argv.p || parseInt(process.env.PORT, 10),
     requestLogger;
 
 if (!argv.s && !argv.silent) {
-  requestLogger = function(req) {
-    log('[%s] "%s %s" "%s"', (new Date).toUTCString(), req.method.cyan, req.url.cyan, req.headers['user-agent']);
-  }
+  requestLogger = function(req, res, error) {
+	var date = (new Date).toUTCString();
+	if (error) {
+		log('[%s] "%s %s" Error (%s): "%s"', date, req.method.red, req.url.red, error.status.toString().red, error.message.red);
+	} else {
+		log('[%s] "%s %s" "%s"', date, req.method.cyan, req.url.cyan, req.headers['user-agent']);
+	}
+  };
 }
 
 if (!port) {

--- a/bin/http-server
+++ b/bin/http-server
@@ -41,12 +41,12 @@ var port = argv.p || parseInt(process.env.PORT, 10),
 
 if (!argv.s && !argv.silent) {
   requestLogger = function(req, res, error) {
-	var date = (new Date).toUTCString();
-	if (error) {
-		log('[%s] "%s %s" Error (%s): "%s"', date, req.method.red, req.url.red, error.status.toString().red, error.message.red);
-	} else {
-		log('[%s] "%s %s" "%s"', date, req.method.cyan, req.url.cyan, req.headers['user-agent']);
-	}
+    var date = (new Date).toUTCString();
+    if (error) {
+      log('[%s] "%s %s" Error (%s): "%s"', date, req.method.red, req.url.red, error.status.toString().red, error.message.red);
+    } else {
+      log('[%s] "%s %s" "%s"', date, req.method.cyan, req.url.cyan, req.headers['user-agent']);
+    }
   };
 }
 

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -34,12 +34,12 @@ var HTTPServer = exports.HTTPServer = function (options) {
   }
 
   var serverOptions = {
-	onError: function(err, req, res){
-		if (options.logFn) {
-			options.logFn(req, res, err);
-		}
-		res.end();
-	},
+    onError: function(err, req, res){
+      if (options.logFn) {
+        options.logFn(req, res, err);
+      }
+      res.end();
+    },
     before: (options.before || []).concat([
       function (req, res) {
         if (options.logFn) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -34,12 +34,17 @@ var HTTPServer = exports.HTTPServer = function (options) {
   }
 
   var serverOptions = {
+	onError: function(err, req, res){
+		if (options.logFn) {
+			options.logFn(req, res, err);
+		}
+		res.end();
+	},
     before: (options.before || []).concat([
       function (req, res) {
         if (options.logFn) {
           options.logFn(req, res);
         }
-
         res.emit('next');
       },
       ecstatic({

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -34,7 +34,7 @@ var HTTPServer = exports.HTTPServer = function (options) {
   }
 
   var serverOptions = {
-    onError: function(err, req, res){
+    onError: function (err, req, res) {
       if (options.logFn) {
         options.logFn(req, res, err);
       }


### PR DESCRIPTION
Currently, when requests fail, there is no indication for that in the console. This code change prints an error message. For example:
[Wed, 04 Feb 2015 21:23:23 GMT] "GET /dummy" Error (404): "Not found"