### PR TITLE
Change default host to 127.0.0.1

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -14,7 +14,7 @@ if (argv.h || argv.help) {
     "",
     "options:",
     "  -p                 Port to use [8080]",
-    "  -a                 Address to use [0.0.0.0]",
+    "  -a                 Address to use [127.0.0.1]",
     "  -d                 Show directory listings [true]",
     "  -i                 Display autoIndex [true]",
     "  -e --ext           Default file extension if none supplied [none]",
@@ -34,7 +34,7 @@ if (argv.h || argv.help) {
 }
 
 var port = argv.p || parseInt(process.env.PORT, 10),
-    host = argv.a || '0.0.0.0',
+    host = argv.a || '127.0.0.1',
     log = (argv.s || argv.silent) ? (function () {}) : console.log,
     ssl = !!argv.S || !!argv.ssl,
     requestLogger;


### PR DESCRIPTION
`0.0.0.0` is non-routable, and non-visitable in Chrome.

`127.0.0.1` is a better default host.