### PR TITLE
Forwarding through reverse proxy for non-static files

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-K` or `--key` Path to ssl key file (default: key.pem).
 
+`-f` or `--forward` Forward to proxy server if static file is not found e.g. -f http://localhost:5000/.
+
 `-h` or `--help` Print this list and exit.
 
 `-c` Set cache time (in seconds) for cache-control max-age header, e.g. -c10 for 10 seconds

--- a/bin/http-server
+++ b/bin/http-server
@@ -28,6 +28,7 @@ if (argv.h || argv.help) {
     "  -C --cert          Path to ssl cert file (default: cert.pem).",
     "  -K --key           Path to ssl key file (default: key.pem).",
     "",
+    "  -f --forward       Forward to proxy server if static file is not found",
     "  -h --help          Print this list and exit."
   ].join('\n'));
   process.exit();
@@ -37,6 +38,7 @@ var port = argv.p || parseInt(process.env.PORT, 10),
     host = argv.a || '0.0.0.0',
     log = (argv.s || argv.silent) ? (function () {}) : console.log,
     ssl = !!argv.S || !!argv.ssl,
+    proxy = argv.f || argv.forward,
     requestLogger;
 
 if (!argv.s && !argv.silent) {
@@ -62,7 +64,8 @@ function listen(port) {
     showDir: argv.d,
     autoIndex: argv.i,
     ext: argv.e || argv.ext,
-    logFn: requestLogger
+    logFn: requestLogger,
+    proxy: proxy
   };
 
   if (argv.cors) {
@@ -88,6 +91,9 @@ function listen(port) {
       + ' on: '.yellow
       + uri.cyan);
 
+    if(proxy){
+        log('Forwarding non static requests to '+proxy);
+    }
     log('Hit CTRL-C to stop the server');
     if (argv.o) {
       opener(uri);

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -1,10 +1,27 @@
 var fs = require('fs'),
     util = require('util'),
     union = require('union'),
-    ecstatic = require('ecstatic');
+    ecstatic = require('ecstatic'),
+    httpProxy = require('http-proxy');
 
 var HTTPServer = exports.HTTPServer = function (options) {
+  var proxyServer;
   options = options || {};
+
+  if (options.proxy) {
+    proxyServer = httpProxy.createProxyServer({});
+    proxyServer.on('error', function (err, req, res) {
+      res.writeHead(500, {
+       'Content-Type': 'text/plain'
+      });
+
+      res.end('Something went wrong. And we are reporting a custom error message.');
+
+      if (options.logFn) {
+        console.log('failed proxy ' + options.proxy);
+      }
+    });
+  }
 
   if (options.root) {
     this.root = options.root;
@@ -28,9 +45,7 @@ var HTTPServer = exports.HTTPServer = function (options) {
   this.autoIndex = options.autoIndex !== 'false';
 
   if (options.ext) {
-    this.ext = options.ext === true
-      ? 'html'
-      : options.ext;
+    this.ext = options.ext === true ? 'html' : options.ext;
   }
 
   var serverOptions = {
@@ -47,8 +62,20 @@ var HTTPServer = exports.HTTPServer = function (options) {
         cache: this.cache,
         showDir: this.showDir,
         autoIndex: this.autoIndex,
-        defaultExt: this.ext
-      })
+        defaultExt: this.ext,
+        handleError: !options.proxy
+      }),
+      function (req, res) {
+        if (options.proxy) {
+          if (options.logFn) {
+            console.log('forwarding');
+          }
+          proxyServer.web(req, res, { target: options.proxy });
+        }
+        else {
+          res.emit('next');
+        }
+      }
     ]),
     headers: this.headers || {}
   };

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "union": "~0.4.3",
     "ecstatic": "~0.5.6",
     "portfinder": "0.2.x",
-    "opener": "~1.4.0"
+    "opener": "~1.4.0",
+    "http-proxy": "~1.8.1"
   },
   "devDependencies": {
     "vows": "0.7.x",


### PR DESCRIPTION
I have added support for basic reverse proxy. The way it works is if file is not found by ecstatic, it will fall back to forwarding the request to a proxy server, configured by -f parameter, for .e.g  http-server -f http://localhost:5000/ etc. This is very basic support to keep in line with spirit of http-server to keep it simple and cli driven. 

We are using this as small replacement of nginx in dev environment. So that static files can be served as well as it works as reverse proxy for rest of the requests. 