### PR TITLE
Use 127.0.0.1 when listening on 0.0.0.0

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -81,16 +81,19 @@ function listen(port) {
 
   var server = httpServer.createServer(options);
   server.listen(port, host, function() {
-    var uri = [ssl ? 'https' : 'http', '://', host, ':', port].join('');
+    var protocol = ssl ? 'https:' : 'http:';
+    var canonical_host = host === "0.0.0.0" ? "127.0.0.1" : host;
+    var uri = protocol + '//' + host + ':' + port;
+    var canonical_uri = protocol + '//' + canonical_host + ':' + port;
     log('Starting up http-server, serving '.yellow
       + server.root.cyan
-      + ((ssl) ? ' through'.yellow + ' https'.cyan : '')
+      + (ssl ? ' through'.yellow + ' https'.cyan : '')
       + ' on: '.yellow
       + uri.cyan);
 
     log('Hit CTRL-C to stop the server');
     if (argv.o) {
-      opener(uri);
+      opener(canonical_uri);
     }
   });
 }


### PR DESCRIPTION
Resolves https://github.com/nodeapps/http-server/issues/128
Contrast to https://github.com/nodeapps/http-server/pull/129
Instead of changing the default to 127.0.0.1, this simply opens 127.0.0.1 as the canonical url for 0.0.0.0