### PR TITLE
Allows explicitly setting cache to 0, closes #158

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -23,7 +23,7 @@ var HTTPServer = exports.HTTPServer = function (options) {
 
   this.headers = options.headers || {};
 
-  this.cache = options.cache || 3600; // in seconds.
+  this.cache = options.cache === undefined ? 3600 : options.cache; // in seconds.
   this.showDir = options.showDir !== 'false';
   this.autoIndex = options.autoIndex !== 'false';
 


### PR DESCRIPTION
This closes https://github.com/indexzero/http-server/issues/158

Should be ok to merge. I strongly feel this is the desired behavior - in normal circumstances you should be able to explicitly set `max-age` to zero.