### PR TITLE
Handle sigterm to exit

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -138,3 +138,8 @@ process.on('SIGINT', function() {
   log('http-server stopped.'.red);
   process.exit();
 });
+
+process.on('SIGTERM', function() {
+  log('http-server stopped.'.red);
+  process.exit();
+});


### PR DESCRIPTION
I run http-server in a docker container.

When docker stop a container, it send a SIGTERM, and after a timeout send a SIGKILL.

By default, node && iojs trap sigterm and does nothing. This trigger the timeout on docker to send a sigkill. 
So basically, stopping a container running `http-server` take some seconds.

Now, it's almost instantaneous. :boom: 