### PR TITLE
Added option to disallow all 3rd party request using CSP

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -26,6 +26,7 @@ if (argv.h || argv.help) {
     '  -s --silent  Suppress log messages from output',
     '  --cors[=headers]   Enable CORS via the "Access-Control-Allow-Origin" header',
     '                     Optionally provide CORS headers list separated by commas',
+    '  --no3p             Disable all 3rd party requests via Content-Security-Policy',
     '  -o [path]    Open browser window after starting the server',
     '  -c           Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.',
     '               To disable caching, use -c-1.',
@@ -107,6 +108,10 @@ function listen(port) {
     if (typeof argv.cors === 'string') {
       options.corsHeaders = argv.cors;
     }
+  }
+
+  if (argv.no3p) {
+    options.no3p = true;
   }
 
   if (ssl) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -76,6 +76,10 @@ function HttpServer(options) {
     } : null));
   }
 
+  if (options.no3p) {
+    this.headers['Content-Security-Policy'] = "default-src 'self'";
+  }
+
   if (options.robots) {
     before.push(function (req, res) {
       if (req.url === '/robots.txt') {


### PR DESCRIPTION
This PR adds a new option `--no3p` which uses `Content-Security-Policy` header to disallow requests to 3rd party domains(for fonts, styles, scripts etc). 
Content Security Policy is [well supported](http://caniuse.com/#feat=contentsecuritypolicy).

**Why?**
Offline docs of some projects I have downloaded,  make 3rd party request for google font, some scripts even analytics. Aside from privacy issue, every time I navigate between pages, they generate lots of requests.
