### PR TITLE
Add option which enables UTC time format for log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-c` Set cache time (in seconds) for cache-control max-age header, e.g. -c10 for 10 seconds (defaults to '3600'). To disable caching, use -c-1.
 
+`-U` or `--utc` Use UTC time format in log messages.
+
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
 `-S` or `--ssl` Enable https.

--- a/bin/http-server
+++ b/bin/http-server
@@ -28,6 +28,7 @@ if (argv.h || argv.help) {
     '  -o [path]    Open browser window after starting the server',
     '  -c           Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.',
     '               To disable caching, use -c-1.',
+    '  -U --utc     Use UTC time format in log messages.',
     '',
     '  -P --proxy   Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
     '',
@@ -45,13 +46,14 @@ var port = argv.p || parseInt(process.env.PORT, 10),
     host = argv.a || '0.0.0.0',
     ssl = !!argv.S || !!argv.ssl,
     proxy = argv.P || argv.proxy,
+    utc = argv.U || argv.utc,
     logger;
 
 if (!argv.s && !argv.silent) {
   logger = {
     info: console.log,
     request: function (req, res, error) {
-      var date = new Date().toUTCString();
+      var date = utc ? new Date().toUTCString() : new Date();
       if (error) {
         logger.info(
           '[%s] "%s %s" Error (%s): "%s"',


### PR DESCRIPTION
I've done a modification which enables using local time in log messages, and added an option `-U --utc` which enables UTC time format.