### PR TITLE
Fix non-showing double-slashes at the end of the protocol

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -113,7 +113,7 @@ function listen(port) {
   var server = httpServer.createServer(options);
   server.listen(port, host, function () {
     var canonicalHost = host === '0.0.0.0' ? '127.0.0.1' : host,
-        protocol      = ssl ? 'https:' : 'http:';
+        protocol      = ssl ? 'https://' : 'http://';
 
     logger.info(['Starting up http-server, serving '.yellow,
       server.root.cyan,
@@ -136,7 +136,7 @@ function listen(port) {
     logger.info('Hit CTRL-C to stop the server');
     if (argv.o) {
       opener(
-        protocol + '//' + canonicalHost + ':' + port,
+        protocol + canonicalHost + ':' + port,
         { command: argv.o !== true ? argv.o : null }
       );
     }


### PR DESCRIPTION
On MacOS and Windows, I experienced that there're missing slashes like this:

```
Starting up http-server, serving ./
Available on:
  [public ips are hidden]
  http:127.0.0.1:8080
Hit CTRL-C to stop the server
```

This commit ensures that the slashes will be there. It doesn't effect the actual work, it's just representational mistake. Some people, including me, may want to copy and paste the URL from there.