### PR TITLE
Push state option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
+`--push-state` Enable HTML5 push state mode where all URIs respond with index.html. (defaults to 'False')
+
 `-S` or `--ssl` Enable https.
 
 `-C` or `--cert` Path to ssl cert file (default: cert.pem).

--- a/bin/http-server
+++ b/bin/http-server
@@ -47,7 +47,6 @@ var port = argv.p || parseInt(process.env.PORT, 10),
     ssl = !!argv.S || !!argv.ssl,
     proxy = argv.P || argv.proxy,
     utc = argv.U || argv.utc,
-    pushState = argv['push-state'] || false,
     logger;
 
 if (!argv.s && !argv.silent) {
@@ -99,9 +98,16 @@ function listen(port) {
     robots: argv.r || argv.robots,
     ext: argv.e || argv.ext,
     logFn: logger.request,
-    proxy: proxy,
-    pushState: pushState
+    proxy: proxy
   };
+
+  if (argv['push-state']) {
+    options.pushState = true;
+
+    if (options.proxy || options.autoIndex) {
+      logger.info('Proxy and Auto Indexing are not supported with Push State.'.red);
+    }
+  }
 
   if (argv.cors) {
     options.cors = true;
@@ -135,6 +141,10 @@ function listen(port) {
 
     if (typeof proxy === 'string') {
       logger.info('Unhandled requests will be served from: ' + proxy);
+    }
+
+    if (options.pushState) {
+      logger.info('HTML5 Push State is enabled, all URLs will be changed to the index page.');
     }
 
     logger.info('Hit CTRL-C to stop the server');

--- a/bin/http-server
+++ b/bin/http-server
@@ -31,7 +31,7 @@ if (argv.h || argv.help) {
     '  -U --utc     Use UTC time format in log messages.',
     '',
     '  -P --proxy   Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
-    '',
+    '  --push-state Enable HTML5 push state mode where all URIs respond with index.html. [false]',
     '  -S --ssl     Enable https.',
     '  -C --cert    Path to ssl cert file (default: cert.pem).',
     '  -K --key     Path to ssl key file (default: key.pem).',
@@ -47,6 +47,7 @@ var port = argv.p || parseInt(process.env.PORT, 10),
     ssl = !!argv.S || !!argv.ssl,
     proxy = argv.P || argv.proxy,
     utc = argv.U || argv.utc,
+    pushState = argv["push-state"] || false,
     logger;
 
 if (!argv.s && !argv.silent) {
@@ -98,7 +99,8 @@ function listen(port) {
     robots: argv.r || argv.robots,
     ext: argv.e || argv.ext,
     logFn: logger.request,
-    proxy: proxy
+    proxy: proxy,
+    pushState: pushState
   };
 
   if (argv.cors) {

--- a/bin/http-server
+++ b/bin/http-server
@@ -47,7 +47,7 @@ var port = argv.p || parseInt(process.env.PORT, 10),
     ssl = !!argv.S || !!argv.ssl,
     proxy = argv.P || argv.proxy,
     utc = argv.U || argv.utc,
-    pushState = argv["push-state"] || false,
+    pushState = argv['push-state'] || false,
     logger;
 
 if (!argv.s && !argv.silent) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -87,6 +87,14 @@ function HttpServer(options) {
     });
   }
 
+  if (options.pushState) {
+    before.push(function (req, res) {
+      req.url = '/index.html';
+
+      res.emit('next');
+    });
+  }
+
   before.push(ecstatic({
     root: this.root,
     cache: this.cache,

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -87,9 +87,31 @@ function HttpServer(options) {
     });
   }
 
-  if (options.pushState) {
-    // When push state is enabled, first rewrite all the URLs to be the index page.
+  var ecstaticMiddleware = ecstatic({
+    root: this.root,
+    cache: this.cache,
+    showDir: this.showDir,
+    autoIndex: this.autoIndex,
+    defaultExt: this.ext,
+    contentType: this.contentType,
+    handleError: typeof options.proxy !== 'string'
+  });
+
+  before.push(ecstaticMiddleware);
+
+  if (typeof options.proxy === 'string') {
+    var proxy = httpProxy.createProxyServer({});
     before.push(function (req, res) {
+      proxy.web(req, res, {
+        target: options.proxy,
+        changeOrigin: true
+      });
+    });
+  }
+
+  if (options.pushState) {
+    // When push state is enabled, rewrite all the URLs to the index page if the status code is a 404.
+    before.push(function (req, res, next) {
       var currentURL = req.url;
       var indexPage = '/index.html';
 
@@ -104,27 +126,7 @@ function HttpServer(options) {
         req.url = indexPage;
       }
 
-      res.emit('next');
-    });
-  }
-
-  before.push(ecstatic({
-    root: this.root,
-    cache: this.cache,
-    showDir: this.showDir,
-    autoIndex: this.autoIndex,
-    defaultExt: this.ext,
-    contentType: this.contentType,
-    handleError: typeof options.proxy !== 'string'
-  }));
-
-  if (typeof options.proxy === 'string') {
-    var proxy = httpProxy.createProxyServer({});
-    before.push(function (req, res) {
-      proxy.web(req, res, {
-        target: options.proxy,
-        changeOrigin: true
-      });
+      ecstaticMiddleware(req, res, next);
     });
   }
 

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -91,9 +91,18 @@ function HttpServer(options) {
     // When push state is enabled, first rewrite all the URLs to be the index page.
     before.push(function (req, res) {
       var currentURL = req.url;
-      var currentParameters = currentURL.slice(currentURL.indexOf("?"));
+      var indexPage = '/index.html';
 
-      req.url = '/index.html' + currentParameters;
+      // Only add paramters when they exist.
+      var parameterStartIndex = currentURL.indexOf('?');
+      if (parameterStartIndex >= 0) {
+        var currentParameters = currentURL.slice(parameterStartIndex);
+
+        req.url = indexPage + currentParameters;
+      }
+      else {
+        req.url = indexPage;
+      }
 
       res.emit('next');
     });

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -88,8 +88,12 @@ function HttpServer(options) {
   }
 
   if (options.pushState) {
+    // When push state is enabled, first rewrite all the URLs to be the index page.
     before.push(function (req, res) {
-      req.url = '/index.html';
+      var currentURL = req.url;
+      var currentParameters = currentURL.slice(currentURL.indexOf("?"));
+
+      req.url = '/index.html' + currentParameters;
 
       res.emit('next');
     });

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -47,6 +47,7 @@ function HttpServer(options) {
   this.showDir = options.showDir !== 'false';
   this.autoIndex = options.autoIndex !== 'false';
   this.contentType = options.contentType || 'application/octet-stream';
+  this.pushState = options.pushState || false;
 
   if (options.ext) {
     this.ext = options.ext === true

--- a/test/fixtures/pushStateRoot/app.js
+++ b/test/fixtures/pushStateRoot/app.js
@@ -1,0 +1,1 @@
+// JavaScript File Exists

--- a/test/fixtures/pushStateRoot/index.html
+++ b/test/fixtures/pushStateRoot/index.html
@@ -1,0 +1,1 @@
+pushState Enabled.

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -170,6 +170,19 @@ vows.describe('http-server').addBatch({
       },
       'status code should be 200': function (res) {
         assert.equal(res.statusCode, 200);
+      },
+      'and file content': {
+        topic: function (res, body) {
+          var self = this;
+          var pushStateRoot = path.join(__dirname, 'fixtures', 'pushStateRoot');
+
+          fs.readFile(path.join(pushStateRoot, 'index.html'), 'utf8', function (err, data) {
+            self.callback(err, data, body);
+          });
+        },
+        'should match content of served file': function (err, file, body) {
+          assert.equal(body.trim(), file.trim());
+        }
       }
     }
   }

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -164,7 +164,7 @@ vows.describe('http-server').addBatch({
 
       this.callback(null, server);
     },
-    'and a non-index file is requested': {
+    'and a non-existant file is requested': {
       topic: function () {
         request('http://127.0.0.1:8083/404', this.callback);
       },
@@ -177,6 +177,24 @@ vows.describe('http-server').addBatch({
           var pushStateRoot = path.join(__dirname, 'fixtures', 'pushStateRoot');
 
           fs.readFile(path.join(pushStateRoot, 'index.html'), 'utf8', function (err, data) {
+            self.callback(err, data, body);
+          });
+        },
+        'should match content of served file': function (err, file, body) {
+          assert.equal(body.trim(), file.trim());
+        }
+      }
+    },
+    'and a file exists': {
+      topic: function () {
+        request('http://127.0.0.1:8083/app.js', this.callback);
+      },
+      'and file content': {
+        topic: function (res, body) {
+          var self = this;
+          var pushStateRoot = path.join(__dirname, 'fixtures', 'pushStateRoot');
+
+          fs.readFile(path.join(pushStateRoot, 'app.js'), 'utf8', function (err, data) {
             self.callback(err, data, body);
           });
         },

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -154,18 +154,19 @@ vows.describe('http-server').addBatch({
   'When push-state is enabled': {
     topic: function () {
       var server = httpServer.createServer({
-        root: root,
-        pushstate: true
+        root: root
       });
-      server.listen(8081);
+      // NOTE: using 8083 because the 808[1-2] are both active and not yet shutdown.
+      server.listen(8083);
+
       this.callback(null, server);
     },
     'and a non-index file is requested': {
       topic: function () {
-        request('http://127.0.0.1:8081/404', this.callback);
+        request('http://127.0.0.1:8083/404', this.callback);
       },
-      'status code should be the enpoint code 200': function (res) {
-        assert.equal(res.statusCode, 200);
+      'status code should be 200': function (res) {
+        assert.equal(res.statusCode, 404);
       }
     }
   }

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -153,8 +153,11 @@ vows.describe('http-server').addBatch({
   },
   'When push-state is enabled': {
     topic: function () {
+      var pushStateRoot = path.join(__dirname, 'fixtures', 'pushStateRoot');
+
       var server = httpServer.createServer({
-        root: root
+        root: pushStateRoot,
+        pushState: true
       });
       // NOTE: using 8083 because the 808[1-2] are both active and not yet shutdown.
       server.listen(8083);
@@ -166,7 +169,7 @@ vows.describe('http-server').addBatch({
         request('http://127.0.0.1:8083/404', this.callback);
       },
       'status code should be 200': function (res) {
-        assert.equal(res.statusCode, 404);
+        assert.equal(res.statusCode, 200);
       }
     }
   }

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -150,5 +150,23 @@ vows.describe('http-server').addBatch({
         assert.equal(res.statusCode, 204);
       }
     }
+  },
+  'When push-state is enabled': {
+    topic: function () {
+      var server = httpServer.createServer({
+        root: root,
+        pushstate: true
+      });
+      server.listen(8081);
+      this.callback(null, server);
+    },
+    'and a non-index file is requested': {
+      topic: function () {
+        request('http://127.0.0.1:8081/404', this.callback);
+      },
+      'status code should be the enpoint code 200': function (res) {
+        assert.equal(res.statusCode, 200);
+      }
+    }
   }
 }).export(module);


### PR DESCRIPTION
First try at implementing an option to support push state by rewriting all request URLs to use `/index.html` instead of the URL requested.

Does this conflict with other options? I'm concerned about changing the requested URL.

This was originally requested as part of  indexzero/http-server#80
