### PR TITLE
Pointing to scripts online is harmful

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@
 
 # Installing globally:
 
-Installation via `npm`.  If you don't have `npm` yet:
-
-     curl https://npmjs.org/install.sh | sh
-
-Once you have `npm`:
+Installation via `npm`:
 
      npm install http-server -g
 


### PR DESCRIPTION
The installation portion to the readme instructs the user to use a shell script provided by npm to install the package manager. This is harmful because it leaves open way too many ambiguities. A safer way would be to instruct the user to use a package manager to install npm (even though most Node installers provide npm by default now).