### PR TITLE
Created fallback option and handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,6 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-r` or `--robots` Provide a /robots.txt (whose content defaults to 'User-agent: *\nDisallow: /')
 
+`-f` or `--fallback` Provide a fallback url if response returns 404 - useful for SPA frameworks
+
 `-h` or `--help` Print this list and exit.

--- a/bin/http-server
+++ b/bin/http-server
@@ -38,6 +38,7 @@ if (argv.h || argv.help) {
     '  -K --key     Path to ssl key file (default: key.pem).',
     '',
     '  -r --robots  Respond to /robots.txt [User-agent: *\\nDisallow: /]',
+    '  -f --fallback Fallback "route" if the request returns a 404.',
     '  -h --help    Print this list and exit.'
   ].join('\n'));
   process.exit();
@@ -48,6 +49,7 @@ var port = argv.p || parseInt(process.env.PORT, 10),
     ssl = !!argv.S || !!argv.ssl,
     proxy = argv.P || argv.proxy,
     utc = argv.U || argv.utc,
+    fallback = argv.f || argv.feedback,
     logger;
 
 if (!argv.s && !argv.silent) {
@@ -114,6 +116,12 @@ function listen(port) {
       cert: argv.C || argv.cert || 'cert.pem',
       key: argv.K || argv.key || 'key.pem'
     };
+  }
+
+  if (fallback) {
+    options.fallback = {
+      address: argv.f || argv.fallback
+    }
   }
 
   var server = httpServer.createServer(options);

--- a/bin/http-server
+++ b/bin/http-server
@@ -121,7 +121,7 @@ function listen(port) {
   if (fallback) {
     options.fallback = {
       address: argv.f || argv.fallback
-    }
+    };
   }
 
   var server = httpServer.createServer(options);

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -113,7 +113,7 @@ function HttpServer(options) {
 
   if (options.fallback) {
     before.push(function (req, res) {
-      if(res.statusCode === 404) {
+      if (res.statusCode === 404) {
         res.redirect(options.fallback.address, 301);
       }
     });

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -111,7 +111,7 @@ function HttpServer(options) {
     });
   }
 
-  if(options.fallback) {
+  if (options.fallback) {
     before.push(function (req, res) {
       if(res.statusCode === 404) {
         res.redirect(options.fallback.address, 301);
@@ -119,12 +119,11 @@ function HttpServer(options) {
     });
   }
 
-
   var serverOptions = {
     before: before,
     headers: this.headers,
     onError: function (err, req, res) {
-      if(err) {
+      if (err) {
         console.log(err);
       }
       if (options.logFn) {
@@ -143,7 +142,6 @@ function HttpServer(options) {
 }
 
 HttpServer.prototype.listen = function () {
-
   this.server.listen.apply(this.server, arguments);
 };
 

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -91,6 +91,8 @@ function HttpServer(options) {
     });
   }
 
+  console.log(!options.fallback || typeof options.proxy === 'string');
+
   before.push(ecstatic({
     root: this.root,
     cache: this.cache,
@@ -98,7 +100,7 @@ function HttpServer(options) {
     autoIndex: this.autoIndex,
     defaultExt: this.ext,
     contentType: this.contentType,
-    handleError: typeof options.proxy !== 'string'
+    handleError: (!options.fallback || typeof options.proxy === 'string')
   }));
 
   if (typeof options.proxy === 'string') {
@@ -111,10 +113,23 @@ function HttpServer(options) {
     });
   }
 
+  if(options.fallback) {
+    before.push(function (req, res) {
+      if(res.statusCode === 404) {
+        res.redirect(options.fallback.address, 301);
+      }
+    });
+  }
+
+
   var serverOptions = {
     before: before,
     headers: this.headers,
     onError: function (err, req, res) {
+      console.log(res.statusCode);
+      if(err) {
+        console.log(err);
+      }
       if (options.logFn) {
         options.logFn(req, res, err);
       }
@@ -131,6 +146,7 @@ function HttpServer(options) {
 }
 
 HttpServer.prototype.listen = function () {
+
   this.server.listen.apply(this.server, arguments);
 };
 

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -91,8 +91,6 @@ function HttpServer(options) {
     });
   }
 
-  console.log(!options.fallback || typeof options.proxy === 'string');
-
   before.push(ecstatic({
     root: this.root,
     cache: this.cache,
@@ -126,7 +124,6 @@ function HttpServer(options) {
     before: before,
     headers: this.headers,
     onError: function (err, req, res) {
-      console.log(res.statusCode);
       if(err) {
         console.log(err);
       }

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -156,31 +156,31 @@ vows.describe('http-server').addBatch({
     }
   },
   'When fallback property is set': {
-    topic: function() {
+    topic: function () {
       var server = httpServer.createServer({
         root: root,
         fallback: {
-          address: "file"
+          address: 'file'
         }
       });
       server.listen(8083);
       this.callback(null, server);
     },
     'when requesting non-existent file': {
-      topic: function() {
+      topic: function () {
         request('http://127.0.0.1:8083/404', this.callback);
       },
-      'status code should be 200': function(res) {
+      'status code should be 200': function (res) {
         assert.equal(res.statusCode, 200);
       },
       'and file content': {
-        topic: function(res, body) {
+        topic: function (res, body) {
           var self = this;
-          fs.readFile(path.join(root, 'file'), 'utf8', function(err, data) {
+          fs.readFile(path.join(root, 'file'), 'utf8', function (err, data) {
             self.callback(err, data, body);
           });
         },
-        'should match content of fallback served file': function(err, file, body) {
+        'should match content of fallback served file': function (err, file, body) {
           assert.equal(body.trim(), file.trim());
         }
       }

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -154,5 +154,36 @@ vows.describe('http-server').addBatch({
         assert.ok(res.headers['access-control-allow-headers'].split(/\s*,\s*/g).indexOf('X-Test') >= 0, 204);
       }
     }
+  },
+  'When fallback property is set': {
+    topic: function() {
+      var server = httpServer.createServer({
+        root: root,
+        fallback: {
+          address: "file"
+        }
+      });
+      server.listen(8083);
+      this.callback(null, server);
+    },
+    'when requesting non-existent file': {
+      topic: function() {
+        request('http://127.0.0.1:8083/404', this.callback);
+      },
+      'status code should be 200': function(res) {
+        assert.equal(res.statusCode, 200);
+      },
+      'and file content': {
+        topic: function(res, body) {
+          var self = this;
+          fs.readFile(path.join(root, 'file'), 'utf8', function(err, data) {
+            self.callback(err, data, body);
+          });
+        },
+        'should match content of fallback served file': function(err, file, body) {
+          assert.equal(body.trim(), file.trim());
+        }
+      }
+    }
   }
 }).export(module);


### PR DESCRIPTION
For those of us using http-server to serve up SPAs (like a simple React site, for instance), we need to be able to provide a fallback address to return to if the route isn't found, so that it can be handled by the SPA framework's router.

This creates a fallback option and provides a test to ensure it works as designed.
