### PR TITLE
Report correct server address

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -127,7 +127,7 @@ function listen(port) {
       '\nAvailable on:'.yellow
     ].join(''));
 
-    if(argv.a && host !== '0.0.0.0') {
+    if (argv.a && host !== '0.0.0.0') {
       logger.info(('  ' + protocol + canonicalHost + ':' + port.toString()).green);
     } else {
       Object.keys(ifaces).forEach(function (dev) {

--- a/bin/http-server
+++ b/bin/http-server
@@ -129,7 +129,8 @@ function listen(port) {
 
     if (argv.a && host !== '0.0.0.0') {
       logger.info(('  ' + protocol + canonicalHost + ':' + port.toString()).green);
-    } else {
+    }
+    else {
       Object.keys(ifaces).forEach(function (dev) {
         ifaces[dev].forEach(function (details) {
           if (details.family === 'IPv4') {

--- a/bin/http-server
+++ b/bin/http-server
@@ -127,13 +127,17 @@ function listen(port) {
       '\nAvailable on:'.yellow
     ].join(''));
 
-    Object.keys(ifaces).forEach(function (dev) {
-      ifaces[dev].forEach(function (details) {
-        if (details.family === 'IPv4') {
-          logger.info(('  ' + protocol + details.address + ':' + port.toString()).green);
-        }
+    if(argv.a && host !== '0.0.0.0') {
+      logger.info(('  ' + protocol + canonicalHost + ':' + port.toString()).green);
+    } else {
+      Object.keys(ifaces).forEach(function (dev) {
+        ifaces[dev].forEach(function (details) {
+          if (details.family === 'IPv4') {
+            logger.info(('  ' + protocol + details.address + ':' + port.toString()).green);
+          }
+        });
       });
-    });
+    }
 
     if (typeof proxy === 'string') {
       logger.info('Unhandled requests will be served from: ' + proxy);


### PR DESCRIPTION
When you specify an address with -a, http-server reports that it listens to all the available interfaces but serves only the address specified (as it should)