### PR TITLE
Adds --hide-dotfiles option

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -38,6 +38,7 @@ if (argv.h || argv.help) {
     '  -K --key     Path to ssl key file (default: key.pem).',
     '',
     '  -r --robots  Respond to /robots.txt [User-agent: *\\nDisallow: /]',
+    '  --no-dotfiles  Do not show dotfiles',
     '  -h --help    Print this list and exit.'
   ].join('\n'));
   process.exit();
@@ -99,7 +100,8 @@ function listen(port) {
     robots: argv.r || argv.robots,
     ext: argv.e || argv.ext,
     logFn: logger.request,
-    proxy: proxy
+    proxy: proxy,
+    showDotfiles: argv.dotfiles
   };
 
   if (argv.cors) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -46,6 +46,7 @@ function HttpServer(options) {
   this.cache = options.cache === undefined ? 3600 : options.cache; // in seconds.
   this.showDir = options.showDir !== 'false';
   this.autoIndex = options.autoIndex !== 'false';
+  this.showDotfiles = options.showDotfiles;
   this.contentType = options.contentType || 'application/octet-stream';
 
   if (options.ext) {
@@ -95,6 +96,7 @@ function HttpServer(options) {
     root: this.root,
     cache: this.cache,
     showDir: this.showDir,
+    showDotfiles: this.showDotfiles,
     autoIndex: this.autoIndex,
     defaultExt: this.ext,
     contentType: this.contentType,

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "colors": "1.0.3",
     "optimist": "0.6.x",
     "union": "~0.4.3",
-    "ecstatic": "~1.2",
+    "ecstatic": "~1.3",
     "http-proxy": "^1.8.1",
     "portfinder": "0.4.x",
     "opener": "~1.4.0",


### PR DESCRIPTION
Hooks up [ecstatic](https://github.com/jfhbrook/node-ecstatic)'s `showDotfiles` option - allows users to hide files beginning with a dot (`.`). Required updating ecstatic to 1.3.1.

I've also written a test, but wasn't able to run existing tests, so haven't committed.
