### PR TITLE
Resolves indexzero/http-server#219

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -119,7 +119,7 @@ function listen(port) {
   var server = httpServer.createServer(options);
   server.listen(port, host, function () {
     var canonicalHost = host === '0.0.0.0' ? '127.0.0.1' : host,
-        protocol      = ssl ? 'https:' : 'http:';
+        protocol      = ssl ? 'https://' : 'http://';
 
     logger.info(['Starting up http-server, serving '.yellow,
       server.root.cyan,


### PR DESCRIPTION
add forward-slash to url output when module starts

fix for iTerm2 users who use the `CMD+left-mouse click` to open url
links from the application's window