### PR TITLE
feat(cors): Adds support for Credentials header

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -71,9 +71,16 @@ function HttpServer(options) {
       options.corsHeaders.split(/\s*,\s*/)
           .forEach(function (h) { this.headers['Access-Control-Allow-Headers'] += ', ' + h; }, this);
     }
-    before.push(corser.create(options.corsHeaders ? {
-      requestHeaders: this.headers['Access-Control-Allow-Headers'].split(/\s*,\s*/)
-    } : null));
+
+    var corserOptions = {
+      supportsCredentials: true
+    };
+
+    if (options.corsHeaders) {
+      corserOptions.requestHeaders = this.headers['Access-Control-Allow-Headers'].split(/\s*,\s*/);
+    }
+
+    before.push(corser.create(corserOptions));
   }
 
   if (options.robots) {


### PR DESCRIPTION
Hello,

I've enabled the CORS Credentials support in corser. In a nutshell, if Access-Control-Allow-Credentials is enabled then Access-Control-Allow-Origin should have the value of the Origin header and not '*'.
