### PR TITLE
Add HTTP Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
+`--username` Username for basic authentication [none]
+
+`--password` Password for basic authentication [none]
+
 `-S` or `--ssl` Enable https.
 
 `-C` or `--cert` Path to ssl cert file (default: cert.pem).

--- a/bin/http-server
+++ b/bin/http-server
@@ -34,6 +34,9 @@ if (argv.h || argv.help) {
     '',
     '  -P --proxy   Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
     '',
+    '  --username   Username for basic authentication [none]',
+    '  --password   Password for basic authentication [none]',
+    '',
     '  -S --ssl     Enable https.',
     '  -C --cert    Path to ssl cert file (default: cert.pem).',
     '  -K --key     Path to ssl key file (default: key.pem).',
@@ -103,7 +106,9 @@ function listen(port) {
     ext: argv.e || argv.ext,
     logFn: logger.request,
     proxy: proxy,
-    showDotfiles: argv.dotfiles
+    showDotfiles: argv.dotfiles,
+    username: argv.username,
+    password: argv.password
   };
 
   if (argv.cors) {

--- a/bin/http-server
+++ b/bin/http-server
@@ -35,7 +35,9 @@ if (argv.h || argv.help) {
     '  -P --proxy   Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
     '',
     '  --username   Username for basic authentication [none]',
+    '               Can also be specified with the env variable NODE_HTTP_SERVER_USERNAME',
     '  --password   Password for basic authentication [none]',
+    '               Can also be specified with the env variable NODE_HTTP_SERVER_PASSWORD',
     '',
     '  -S --ssl     Enable https.',
     '  -C --cert    Path to ssl cert file (default: cert.pem).',
@@ -107,8 +109,8 @@ function listen(port) {
     logFn: logger.request,
     proxy: proxy,
     showDotfiles: argv.dotfiles,
-    username: argv.username,
-    password: argv.password
+    username: argv.username || process.env.NODE_HTTP_SERVER_USERNAME,
+    password: argv.password || process.env.NODE_HTTP_SERVER_PASSWORD
   };
 
   if (argv.cors) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -3,6 +3,7 @@
 var fs = require('fs'),
     union = require('union'),
     ecstatic = require('ecstatic'),
+    auth = require('basic-auth'),
     httpProxy = require('http-proxy'),
     corser = require('corser');
 
@@ -65,6 +66,20 @@ function HttpServer(options) {
 
     res.emit('next');
   });
+
+  if (options.username || options.password) {
+    before.push(function (req, res) {
+      var credentials = auth(req);
+
+      if (credentials && credentials.name === options.username && credentials.pass === options.password) {
+        return res.emit('next');
+      }
+
+      res.statusCode = 401;
+      res.setHeader('WWW-Authenticate', 'Basic realm=""');
+      res.end('Access denied');
+    });
+  }
 
   if (options.cors) {
     this.headers['Access-Control-Allow-Origin'] = '*';

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -5,7 +5,8 @@ var fs = require('fs'),
     ecstatic = require('ecstatic'),
     auth = require('basic-auth'),
     httpProxy = require('http-proxy'),
-    corser = require('corser');
+    corser = require('corser'),
+    secureCompare = require('secure-compare');
 
 //
 // Remark: backwards compatibility for previous
@@ -71,8 +72,15 @@ function HttpServer(options) {
     before.push(function (req, res) {
       var credentials = auth(req);
 
-      if (credentials && credentials.name === options.username && credentials.pass === options.password) {
-        return res.emit('next');
+      // We perform these outside the if to avoid short-circuiting and giving
+      // an attacker knowledge of whether the username is correct via a timing
+      // attack.
+      if (credentials) {
+        var usernameEqual = secureCompare(options.username, credentials.name);
+        var passwordEqual = secureCompare(options.password, credentials.pass);
+        if (usernameEqual && passwordEqual) {
+          return res.emit('next');
+        }
       }
 
       res.statusCode = 401;

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     }
   ],
   "dependencies": {
+    "basic-auth": "^1.0.3",
     "colors": "1.0.3",
     "corser": "~2.0.0",
     "ecstatic": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "opener": "~1.4.0",
     "optimist": "0.6.x",
     "portfinder": "^1.0.13",
+    "secure-compare": "3.0.1",
     "union": "~0.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Built on the work of @jondlm in #51. Using what I figured was the most popular basic auth library: https://www.npmjs.com/package/basic-auth

Can be configured with CLI options or env variables (separated out into its own commit in case you don't want that).

I've erred on the generous side when it comes to tests, as people will probably be pretty peeved if this stops working in some non-obvious way!
