### PR TITLE
Allow Open -o with both relative & absolute paths

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -146,10 +146,13 @@ function listen(port) {
 
     logger.info('Hit CTRL-C to stop the server');
     if (argv.o) {
-      opener(
-        protocol + '//' + canonicalHost + ':' + port,
-        { command: argv.o !== true ? argv.o : null }
-      );
+      var baseUrl = protocol + '//' + canonicalHost + ':' + port;
+      if (typeof argv.o === 'string' && argv.o.charAt(0) === '/') {
+        opener(baseUrl + argv.o);
+      }
+      else {
+        opener(baseUrl, { command: argv.o !== true ? argv.o : null });
+      }
     }
   });
 }


### PR DESCRIPTION
Allows the use of both absolute and relative paths when using the open flag [-o]. This is a none breaking change as currently the Open option just doesnt work (in my tests) if starting with a forward slash.

Allowing absolute paths is important as someone might want to force the use of a particular host that doesnt want to use the value in canonicalHost. 

It determines whether it is a relative path or not simply by checking whether the -o argument starts with a forward slash, anything else passes through as before.
