### PR TITLE
update portfinder version to fix auto increment port

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "http-proxy": "^1.8.1",
     "opener": "~1.4.0",
     "optimist": "0.6.x",
-    "portfinder": "0.4.x",
+    "portfinder": "~1.0.2",
     "union": "~0.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Old version of portfinder is broken and does not find an open port.

Fixes issue: https://github.com/indexzero/http-server/issues/215
