### PR TITLE
Fix crash on Windows Subsystem for Linux

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -127,7 +127,7 @@ function listen(port) {
       '\nAvailable on:'.yellow
     ].join(''));
 
-    if (argv.a || host !== '0.0.0.0') {
+    if (host === '0.0.0.0') {
       logger.info(('  ' + protocol + canonicalHost + ':' + port.toString()).green);
     }
     else {

--- a/bin/http-server
+++ b/bin/http-server
@@ -11,8 +11,6 @@ var colors     = require('colors'),
       .boolean('cors')
       .argv;
 
-var ifaces = os.networkInterfaces();
-
 if (argv.h || argv.help) {
   console.log([
     'usage: http-server [path] [options]',
@@ -129,10 +127,12 @@ function listen(port) {
       '\nAvailable on:'.yellow
     ].join(''));
 
-    if (argv.a && host !== '0.0.0.0') {
+    if (argv.a || host !== '0.0.0.0') {
       logger.info(('  ' + protocol + canonicalHost + ':' + port.toString()).green);
     }
     else {
+      var ifaces = os.networkInterfaces();
+
       Object.keys(ifaces).forEach(function (dev) {
         ifaces[dev].forEach(function (details) {
           if (details.family === 'IPv4') {


### PR DESCRIPTION
Since "Windows Subsystem for Linux" hasn't yet implemented the Linux API to list the network interfaces, it was crashing when running `os.networkInterfaces();` method.
