### PR TITLE
Use safe colors to avoid header problems

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -2,7 +2,7 @@
 
 'use strict';
 
-var colors     = require('colors'),
+var colors     = require('colors/safe'),
     os         = require('os'),
     httpServer = require('../lib/http-server'),
     portfinder = require('portfinder'),

--- a/bin/http-server
+++ b/bin/http-server
@@ -59,14 +59,14 @@ if (!argv.s && !argv.silent) {
       if (error) {
         logger.info(
           '[%s] "%s %s" Error (%s): "%s"',
-          date, req.method.red, req.url.red,
-          error.status.toString().red, error.message.red
+          date, colors.red(req.method), colors.red(req.url),
+          colors.red(error.status.toString()), colors.red(error.message)
         );
       }
       else {
         logger.info(
           '[%s] "%s %s" "%s"',
-          date, req.method.cyan, req.url.cyan,
+          date, colors.cyan(req.method), colors.cyan(req.url),
           req.headers['user-agent']
         );
       }
@@ -123,20 +123,20 @@ function listen(port) {
     var canonicalHost = host === '0.0.0.0' ? '127.0.0.1' : host,
         protocol      = ssl ? 'https://' : 'http://';
 
-    logger.info(['Starting up http-server, serving '.yellow,
-      server.root.cyan,
-      ssl ? (' through'.yellow + ' https'.cyan) : '',
-      '\nAvailable on:'.yellow
+    logger.info([colors.yellow('Starting up http-server, serving '),
+      colors.cyan(server.root),
+      ssl ? (colors.yellow(' through') + colors.cyan(' https')) : '',
+      colors.yellow('\nAvailable on:')
     ].join(''));
 
     if (argv.a && host !== '0.0.0.0') {
-      logger.info(('  ' + protocol + canonicalHost + ':' + port.toString()).green);
+      logger.info(('  ' + protocol + canonicalHost + ':' + colors.green(port.toString())));
     }
     else {
       Object.keys(ifaces).forEach(function (dev) {
         ifaces[dev].forEach(function (details) {
           if (details.family === 'IPv4') {
-            logger.info(('  ' + protocol + details.address + ':' + port.toString()).green);
+            logger.info(('  ' + protocol + details.address + ':' + colors.green(port.toString())));
           }
         });
       });
@@ -166,11 +166,11 @@ if (process.platform === 'win32') {
 }
 
 process.on('SIGINT', function () {
-  logger.info('http-server stopped.'.red);
+  logger.info(colors.red('http-server stopped.'));
   process.exit();
 });
 
 process.on('SIGTERM', function () {
-  logger.info('http-server stopped.'.red);
+  logger.info(colors.red('http-server stopped.'));
   process.exit();
 });


### PR DESCRIPTION
The `union` module iterates over a map of headers. If the supplied `headers` object is a thing and `colors` is loaded in it's "normal" (not "safe") mode, `union` will try to set headers like "bold" and "red" which contain shell color codes. Node will complain about these invalid header character and throw an exception:

```
_http_outgoing.js:351
      throw new TypeError('The header content contains invalid characters');
      ^

TypeError: The header content contains invalid characters
    at ServerResponse.OutgoingMessage.setHeader (_http_outgoing.js:351:13)
    at ResponseStream.writeHead (/Users/lnwdr/temp/testproject/node_modules/http-server/node_modules/union/lib/response-stream.js:78:21)
```
