### PR TITLE
Update ecstatic

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "colors": "1.0.3",
     "corser": "~2.0.0",
-    "ecstatic": "^1.4.0",
+    "ecstatic": "^2.0.0",
     "http-proxy": "^1.8.1",
     "opener": "~1.4.0",
     "optimist": "0.6.x",


### PR DESCRIPTION
Ecstatic v2 includes a security fix and addresses a bug which causes jenkins builds to crash.

Currently, __any project using http-server may be crashing when built in jenkins__. Please consider merging this and making a new release as soon as possible, this would be very much appreciated ❤️ 

For reference:
- [changelog](https://github.com/jfhbrook/node-ecstatic/blob/2.0.0/CHANGELOG.md)
- [CI crash issue](https://github.com/jfhbrook/node-ecstatic/issues/128)