### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test
+screenshots
+.travis.yml


### PR DESCRIPTION
Files which are not useful to the end user, such as tests and build resources should be excluded from the npm package as it saves everyone bandwidth and time.

I'm not sure if the `public` folder is used only for tests or if it is useful to run http-server. If not, please feel free to add it or let me know and I'll add it for you.