### PR TITLE
Aggressively turn off caching when cache time set to -1

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -47,7 +47,7 @@ function HttpServer(options) {
     options.cache === undefined ? 3600 :
     // -1 is a special case to turn off caching.
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Preventing_caching
-    options.cache === -1 ? "no-cache, no-store, must-revalidate" :
+    options.cache === -1 ? 'no-cache, no-store, must-revalidate' :
     options.cache // in seconds.
     );
   this.showDir = options.showDir !== 'false';

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -43,7 +43,13 @@ function HttpServer(options) {
 
   this.headers = options.headers || {};
 
-  this.cache = options.cache === undefined ? 3600 : options.cache; // in seconds.
+  this.cache = (
+    options.cache === undefined ? 3600 :
+    // -1 is a special case to turn off caching.
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Preventing_caching
+    options.cache === -1 ? "no-cache, no-store, must-revalidate" :
+    options.cache // in seconds.
+    );
   this.showDir = options.showDir !== 'false';
   this.autoIndex = options.autoIndex !== 'false';
   this.gzip = options.gzip === true;

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -49,7 +49,7 @@ function HttpServer(options) {
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Preventing_caching
     options.cache === -1 ? 'no-cache, no-store, must-revalidate' :
     options.cache // in seconds.
-    );
+  );
   this.showDir = options.showDir !== 'false';
   this.autoIndex = options.autoIndex !== 'false';
   this.gzip = options.gzip === true;


### PR DESCRIPTION
This is a fix for https://github.com/indexzero/http-server/issues/149.

It accounts for the special case of `cache` being set to `-1` and, in that case, sets the cache header to `no-cache, no-store, must-revalidate` to really make sure nothing tries to cache responses from the server.