### PR TITLE
Added compression middleware under --compression to gzip responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ This will install `http-server` globally so that it may be run from the command 
 
 `--cors` Enable CORS via the `Access-Control-Allow-Origin` header
 
+`--compression` Enable gzip compression via [compression middleware](https://www.npmjs.com/package/compression)
+
 `-o` Open browser window after starting the server
 
 `-c` Set cache time (in seconds) for cache-control max-age header, e.g. -c10 for 10 seconds (defaults to '3600'). To disable caching, use -c-1.

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -4,7 +4,8 @@ var fs = require('fs'),
     union = require('union'),
     ecstatic = require('ecstatic'),
     httpProxy = require('http-proxy'),
-    corser = require('corser');
+    corser = require('corser'),
+    compression = require('compression');
 
 //
 // Remark: backwards compatibility for previous
@@ -90,6 +91,10 @@ function HttpServer(options) {
 
       res.emit('next');
     });
+  }
+
+  if (options.compression) {
+    before.push(compression({ level: 9 }));
   }
 
   before.push(ecstatic({

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   ],
   "dependencies": {
     "colors": "1.0.3",
+    "compression": "^1.6.2",
     "corser": "~2.0.0",
     "ecstatic": "^2.0.0",
     "http-proxy": "^1.8.1",


### PR DESCRIPTION
Creating those .gz files could add to much work for dev. This is why if we compress the response by default using a cli flag might be better.