### PR TITLE
Fallback option for single page applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
+`-D` or `--default` Default url path to serve if the request cannot be resolved. e.g.: /index.html
+
 `-S` or `--ssl` Enable https.
 
 `-C` or `--cert` Path to ssl cert file (default: cert.pem).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
-`-f` or `--fallback` Default url path to serve if the request cannot be resolved. e.g.: /index.html (Fallback will only be used for GET requests for .htm and .html files.)
+`-f` or `--fallback` Default url path to serve if the request cannot be resolved. e.g.: /index.html (Fallback will only be used for GET requests with an URL ending with `/`, `.htm` or `.html`.)
 
 `-S` or `--ssl` Enable https.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
-`-D` or `--default` Default url path to serve if the request cannot be resolved. e.g.: /index.html
+`-f` or `--fallback` Default url path to serve if the request cannot be resolved. e.g.: /index.html
 
 `-S` or `--ssl` Enable https.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
-`-f` or `--fallback` Default url path to serve if the request cannot be resolved. e.g.: /index.html (Fallback will only be used for GET requests with an URL ending with `/`, `.htm` or `.html`.)
+`-f` or `--fallback` Default url path to serve if the request cannot be resolved. e.g.: /index.html (Fallback will only be used for GET requests with an URL ending with a path segment without an extension or with one of the extensions `.htm` or `.html`.)
 
 `-S` or `--ssl` Enable https.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
-`-f` or `--fallback` Default url path to serve if the request cannot be resolved. e.g.: /index.html
+`-f` or `--fallback` Default url path to serve if the request cannot be resolved. e.g.: /index.html (Fallback will only be used for GET requests for .htm and .html files.)
 
 `-S` or `--ssl` Enable https.
 

--- a/bin/http-server
+++ b/bin/http-server
@@ -18,29 +18,29 @@ if (argv.h || argv.help) {
     'usage: http-server [path] [options]',
     '',
     'options:',
-    '  -p            Port to use [8080]',
-    '  -a            Address to use [0.0.0.0]',
-    '  -d            Show directory listings [true]',
-    '  -i            Display autoIndex [true]',
-    '  -g --gzip     Serve gzip files when possible [false]',
-    '  -e --ext      Default file extension if none supplied [none]',
-    '  -s --silent   Suppress log messages from output',
+    '  -p             Port to use [8080]',
+    '  -a             Address to use [0.0.0.0]',
+    '  -d             Show directory listings [true]',
+    '  -i             Display autoIndex [true]',
+    '  -g --gzip      Serve gzip files when possible [false]',
+    '  -e --ext       Default file extension if none supplied [none]',
+    '  -s --silent    Suppress log messages from output',
     '  --cors[=headers]   Enable CORS via the "Access-Control-Allow-Origin" header',
     '                     Optionally provide CORS headers list separated by commas',
-    '  -o [path]     Open browser window after starting the server',
-    '  -c            Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.',
-    '                To disable caching, use -c-1.',
-    '  -U --utc      Use UTC time format in log messages.',
+    '  -o [path]      Open browser window after starting the server',
+    '  -c             Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.',
+    '                 To disable caching, use -c-1.',
+    '  -U --utc       Use UTC time format in log messages.',
     '',
-    '  -P --proxy    Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
-    '  -D --default  Default url path to serve if the request cannot be resolved. e.g.: /index.html',
+    '  -P --proxy     Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
+    '  -f --fallback  Default url path to serve if the request cannot be resolved. e.g.: /index.html',
     '',
-    '  -S --ssl      Enable https.',
-    '  -C --cert     Path to ssl cert file (default: cert.pem).',
-    '  -K --key      Path to ssl key file (default: key.pem).',
+    '  -S --ssl       Enable https.',
+    '  -C --cert      Path to ssl cert file (default: cert.pem).',
+    '  -K --key       Path to ssl key file (default: key.pem).',
     '',
-    '  -r --robots   Respond to /robots.txt [User-agent: *\\nDisallow: /]',
-    '  -h --help     Print this list and exit.'
+    '  -r --robots    Respond to /robots.txt [User-agent: *\\nDisallow: /]',
+    '  -h --help      Print this list and exit.'
   ].join('\n'));
   process.exit();
 }
@@ -49,7 +49,6 @@ var port = argv.p || parseInt(process.env.PORT, 10),
     host = argv.a || '0.0.0.0',
     ssl = !!argv.S || !!argv.ssl,
     proxy = argv.P || argv.proxy,
-    defaultUrlPath = argv.D || argv.default,
     utc = argv.U || argv.utc,
     logger;
 
@@ -104,7 +103,7 @@ function listen(port) {
     ext: argv.e || argv.ext,
     logFn: logger.request,
     proxy: proxy,
-    defaultUrlPath: defaultUrlPath
+    fallback: argv.f || argv.fallback
   };
 
   if (argv.cors) {

--- a/bin/http-server
+++ b/bin/http-server
@@ -34,7 +34,7 @@ if (argv.h || argv.help) {
     '',
     '  -P --proxy     Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
     '  -f --fallback  Default url path to serve if the request cannot be resolved. e.g.: /index.html',
-    '                 (Fallback will only be used for GET requests with an URL ending with /, .htm or .html.)',
+    '                 (Fallback will only be used for GET requests with an URL ending with a path segment without an extension or with one of the extensions .htm or .html.)',
     '',
     '  -S --ssl       Enable https.',
     '  -C --cert      Path to ssl cert file (default: cert.pem).',

--- a/bin/http-server
+++ b/bin/http-server
@@ -34,6 +34,7 @@ if (argv.h || argv.help) {
     '',
     '  -P --proxy     Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
     '  -f --fallback  Default url path to serve if the request cannot be resolved. e.g.: /index.html',
+    '                 (Fallback will only be used for GET requests for .htm and .html files.)',
     '',
     '  -S --ssl       Enable https.',
     '  -C --cert      Path to ssl cert file (default: cert.pem).',

--- a/bin/http-server
+++ b/bin/http-server
@@ -55,13 +55,19 @@ var port = argv.p || parseInt(process.env.PORT, 10),
 if (!argv.s && !argv.silent) {
   logger = {
     info: console.log,
-    request: function (req, res, error) {
+    request: function (req, res, error, fallback) {
       var date = utc ? new Date().toUTCString() : new Date();
       if (error) {
         logger.info(
           '[%s] "%s %s" Error (%s): "%s"',
           date, colors.red(req.method), colors.red(req.url),
           colors.red(error.status.toString()), colors.red(error.message)
+        );
+      }
+      else if (fallback) {
+        logger.info(
+          '[%s] %s %s not found, serving %s instead',
+          date, colors.magenta("Fallback:"), req.url, fallback
         );
       }
       else {

--- a/bin/http-server
+++ b/bin/http-server
@@ -34,7 +34,7 @@ if (argv.h || argv.help) {
     '',
     '  -P --proxy     Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
     '  -f --fallback  Default url path to serve if the request cannot be resolved. e.g.: /index.html',
-    '                 (Fallback will only be used for GET requests for .htm and .html files.)',
+    '                 (Fallback will only be used for GET requests with an URL ending with /, .htm or .html.)',
     '',
     '  -S --ssl       Enable https.',
     '  -C --cert      Path to ssl cert file (default: cert.pem).',

--- a/bin/http-server
+++ b/bin/http-server
@@ -67,8 +67,9 @@ if (!argv.s && !argv.silent) {
       }
       else if (fallback) {
         logger.info(
-          '[%s] %s %s not found, serving %s instead',
-          date, colors.magenta("Fallback:"), req.url, fallback
+          '[%s] "%s %s" Fallback: serving %s instead',
+          date, colors.magenta(req.method), colors.magenta(req.url),
+          fallback
         );
       }
       else {

--- a/bin/http-server
+++ b/bin/http-server
@@ -18,28 +18,29 @@ if (argv.h || argv.help) {
     'usage: http-server [path] [options]',
     '',
     'options:',
-    '  -p           Port to use [8080]',
-    '  -a           Address to use [0.0.0.0]',
-    '  -d           Show directory listings [true]',
-    '  -i           Display autoIndex [true]',
-    '  -g --gzip    Serve gzip files when possible [false]',
-    '  -e --ext     Default file extension if none supplied [none]',
-    '  -s --silent  Suppress log messages from output',
+    '  -p            Port to use [8080]',
+    '  -a            Address to use [0.0.0.0]',
+    '  -d            Show directory listings [true]',
+    '  -i            Display autoIndex [true]',
+    '  -g --gzip     Serve gzip files when possible [false]',
+    '  -e --ext      Default file extension if none supplied [none]',
+    '  -s --silent   Suppress log messages from output',
     '  --cors[=headers]   Enable CORS via the "Access-Control-Allow-Origin" header',
     '                     Optionally provide CORS headers list separated by commas',
-    '  -o [path]    Open browser window after starting the server',
-    '  -c           Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.',
-    '               To disable caching, use -c-1.',
-    '  -U --utc     Use UTC time format in log messages.',
+    '  -o [path]     Open browser window after starting the server',
+    '  -c            Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.',
+    '                To disable caching, use -c-1.',
+    '  -U --utc      Use UTC time format in log messages.',
     '',
-    '  -P --proxy   Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
+    '  -P --proxy    Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
+    '  -D --default  Default url path to serve if the request cannot be resolved. e.g.: /index.html',
     '',
-    '  -S --ssl     Enable https.',
-    '  -C --cert    Path to ssl cert file (default: cert.pem).',
-    '  -K --key     Path to ssl key file (default: key.pem).',
+    '  -S --ssl      Enable https.',
+    '  -C --cert     Path to ssl cert file (default: cert.pem).',
+    '  -K --key      Path to ssl key file (default: key.pem).',
     '',
-    '  -r --robots  Respond to /robots.txt [User-agent: *\\nDisallow: /]',
-    '  -h --help    Print this list and exit.'
+    '  -r --robots   Respond to /robots.txt [User-agent: *\\nDisallow: /]',
+    '  -h --help     Print this list and exit.'
   ].join('\n'));
   process.exit();
 }
@@ -48,6 +49,7 @@ var port = argv.p || parseInt(process.env.PORT, 10),
     host = argv.a || '0.0.0.0',
     ssl = !!argv.S || !!argv.ssl,
     proxy = argv.P || argv.proxy,
+    defaultUrlPath = argv.D || argv.default,
     utc = argv.U || argv.utc,
     logger;
 
@@ -101,7 +103,8 @@ function listen(port) {
     robots: argv.r || argv.robots,
     ext: argv.e || argv.ext,
     logFn: logger.request,
-    proxy: proxy
+    proxy: proxy,
+    defaultUrlPath: defaultUrlPath
   };
 
   if (argv.cors) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -100,7 +100,7 @@ function HttpServer(options) {
     defaultExt: this.ext,
     gzip: this.gzip,
     contentType: this.contentType,
-    handleError: typeof options.proxy !== 'string' && typeof options.defaultUrlPath !== 'string'
+    handleError: typeof options.proxy !== 'string' && typeof options.fallback !== 'string'
   });
   before.push(ecstaticMiddleware);
 
@@ -114,9 +114,9 @@ function HttpServer(options) {
     });
   }
 
-  if (typeof options.defaultUrlPath === 'string') {
+  if (typeof options.fallback === 'string') {
     before.push(function (req, res, next) {
-      req.url = (options.defaultUrlPath[0] !== '/' ? '/' : '') + options.defaultUrlPath;
+      req.url = (options.fallback[0] !== '/' ? '/' : '') + options.fallback;
       ecstaticMiddleware(req, res, next);
     });
   }

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -116,7 +116,9 @@ function HttpServer(options) {
 
   if (typeof options.fallback === 'string') {
     before.push(function (req, res, next) {
-      req.url = (options.fallback[0] !== '/' ? '/' : '') + options.fallback;
+      var fallback = (options.fallback[0] !== '/' ? '/' : '') + options.fallback;
+      options.logFn(req, res, null, fallback);
+      req.url = fallback;
       ecstaticMiddleware(req, res, next);
     });
   }

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var fs = require('fs'),
+    path = require('path'),
+    url = require('url'),
     union = require('union'),
     ecstatic = require('ecstatic'),
     httpProxy = require('http-proxy'),
@@ -118,7 +120,9 @@ function HttpServer(options) {
     var fallback = (options.fallback[0] !== '/' ? '/' : '') + options.fallback;
 
     before.push(function (req, res) {
-      if (req.method.toUpperCase() !== 'GET' || !req.url.match(/(\/|\.html?)$/i)) {
+      var parsedUrl = url.parse(req.url);
+      var ext = path.extname(parsedUrl.pathname);
+      if (req.method.toUpperCase() !== 'GET' || ['.html', '.htm', '.', ''].indexOf(ext) === -1) {
         res.emit('next');
         return;
       }

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -115,13 +115,13 @@ function HttpServer(options) {
   }
 
   if (typeof options.fallback === 'string') {
+    var fallback = (options.fallback[0] !== '/' ? '/' : '') + options.fallback;
+
     before.push(function (req, res) {
       if (req.method.toUpperCase() !== 'GET' || !req.url.match(/(\/|\.html?)$/i)) {
         res.emit('next');
         return;
       }
-
-      var fallback = (options.fallback[0] !== '/' ? '/' : '') + options.fallback;
 
       if (options.logFn) {
         options.logFn(req, res, null, fallback);

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -115,15 +115,16 @@ function HttpServer(options) {
   }
 
   if (typeof options.fallback === 'string') {
-    before.push(function (req, res, next) {
+    before.push(function (req, res) {
       if (req.method.toUpperCase() !== 'GET' || !req.url.match(/(\/|\.html?)$/i)) {
-        return next();
+        res.emit('next');
+        return;
       }
 
       var fallback = (options.fallback[0] !== '/' ? '/' : '') + options.fallback;
       options.logFn(req, res, null, fallback);
       req.url = fallback;
-      ecstaticMiddleware(req, res, next);
+      return ecstaticMiddleware(req, res);
     });
   }
 

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -116,6 +116,10 @@ function HttpServer(options) {
 
   if (typeof options.fallback === 'string') {
     before.push(function (req, res, next) {
+      if (req.method.toUpperCase() !== 'GET' || !req.url.match(/(\/|\.html?)$/i)) {
+        return next();
+      }
+
       var fallback = (options.fallback[0] !== '/' ? '/' : '') + options.fallback;
       options.logFn(req, res, null, fallback);
       req.url = fallback;

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -92,7 +92,7 @@ function HttpServer(options) {
     });
   }
 
-  before.push(ecstatic({
+  var ecstaticMiddleware = ecstatic({
     root: this.root,
     cache: this.cache,
     showDir: this.showDir,
@@ -100,8 +100,9 @@ function HttpServer(options) {
     defaultExt: this.ext,
     gzip: this.gzip,
     contentType: this.contentType,
-    handleError: typeof options.proxy !== 'string'
-  }));
+    handleError: typeof options.proxy !== 'string' && typeof options.defaultUrlPath !== 'string'
+  });
+  before.push(ecstaticMiddleware);
 
   if (typeof options.proxy === 'string') {
     var proxy = httpProxy.createProxyServer({});
@@ -110,6 +111,13 @@ function HttpServer(options) {
         target: options.proxy,
         changeOrigin: true
       });
+    });
+  }
+
+  if (typeof options.defaultUrlPath === 'string') {
+    before.push(function (req, res, next) {
+      req.url = (options.defaultUrlPath[0] !== '/' ? '/' : '') + options.defaultUrlPath;
+      ecstaticMiddleware(req, res, next);
     });
   }
 

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -122,7 +122,11 @@ function HttpServer(options) {
       }
 
       var fallback = (options.fallback[0] !== '/' ? '/' : '') + options.fallback;
-      options.logFn(req, res, null, fallback);
+
+      if (options.logFn) {
+        options.logFn(req, res, null, fallback);
+      }
+
       req.url = fallback;
       return ecstaticMiddleware(req, res);
     });

--- a/package.json
+++ b/package.json
@@ -59,6 +59,10 @@
     {
       "name": "BigBlueHat",
       "email": "byoung@bigbluehat.com"
+    },
+    {
+      "name": "Stefan Kleeschulte",
+      "url": "https://github.com/skleeschulte"
     }
   ],
   "dependencies": {

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -155,7 +155,7 @@ vows.describe('http-server').addBatch({
       }
     }
   },
-  'When a default file is configured': {
+  'When a fallback file is configured': {
     topic: function () {
       var server = httpServer.createServer({
         root: root,

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -166,7 +166,7 @@ vows.describe('http-server').addBatch({
     },
     'and a non existent file requested': {
       topic: function () {
-        request('http://127.0.0.1:4000/404', this.callback);
+        request('http://127.0.0.1:4000/does-not-exist.html', this.callback);
       },
       'status code should be 200': function (err, res) {
         assert.equal(res.statusCode, 200);

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -159,7 +159,7 @@ vows.describe('http-server').addBatch({
     topic: function () {
       var server = httpServer.createServer({
         root: root,
-        defaultUrlPath: '/file'
+        fallback: '/file'
       });
       server.listen(4000);
       this.callback(null, server);

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -154,5 +154,53 @@ vows.describe('http-server').addBatch({
         assert.ok(res.headers['access-control-allow-headers'].split(/\s*,\s*/g).indexOf('X-Test') >= 0, 204);
       }
     }
+  },
+  'When a default file is configured': {
+    topic: function () {
+      var server = httpServer.createServer({
+        root: root,
+        defaultUrlPath: '/file'
+      });
+      server.listen(4000);
+      this.callback(null, server);
+    },
+    'and a non existent file requested': {
+      topic: function () {
+        request('http://127.0.0.1:4000/404', this.callback);
+      },
+      'status code should be 200': function (err, res) {
+        assert.equal(res.statusCode, 200);
+      },
+      'the content of the default file': {
+        topic: function (res, body) {
+          var self = this;
+          fs.readFile(path.join(root, 'file'), 'utf8', function (err, data) {
+            self.callback(err, data, body);
+          });
+        },
+        'should match the content of the response': function (err, file, body) {
+          assert.equal(body.trim(), file.trim());
+        }
+      }
+    },
+    'and an existing file requested': {
+      topic: function () {
+        request('http://127.0.0.1:4000/canYouSeeMe', this.callback);
+      },
+      'status code should be 200': function (err, res) {
+        assert.equal(res.statusCode, 200);
+      },
+      'the content of the requested file': {
+        topic: function (res, body) {
+          var self = this;
+          fs.readFile(path.join(root, 'canYouSeeMe'), 'utf8', function (err, data) {
+            self.callback(err, data, body);
+          });
+        },
+        'should match the content of the response': function (err, file, body) {
+          assert.equal(body.trim(), file.trim());
+        }
+      }
+    }
   }
 }).export(module);


### PR DESCRIPTION
I implemented the option to specify a default url path that is used to respond to unresolved requests (e.g. client requests /login which does not exist on the server -> server responds as if asked for /index.html). This is very helpful when serving a single page app, where everything that does not resolve to a resource on the server shall be served with the SPA entry file (e.g. index.html) *without redirecting* the client.

I chose to implement a "default url" rather than a "default file path", because this way it is straight forward to use the existing ecstatic instance: if the ecstatic middleware does not handle the initial request, `req.url` is simply replaced with the configured default url and the request is passed to the same ecstatic middleware again.

If somebody wants to use this before it is (or if it is not) merged:
`npm install skleeschulte/http-server --save`
And then use `-f` or `--fallback` parameter:
`http-server ./root -f /index.html`

Related issues: #7 #80 #198 #286 #318 #331 #338 #367