### PR TITLE
Remove extra slashes (fixes `-o` command)

### DIFF
--- a/bin/http-server
+++ b/bin/http-server
@@ -149,7 +149,7 @@ function listen(port) {
     logger.info('Hit CTRL-C to stop the server');
     if (argv.o) {
       opener(
-        protocol + '//' + canonicalHost + ':' + port,
+        protocol + canonicalHost + ':' + port,
         { command: argv.o !== true ? argv.o : null }
       );
     }


### PR DESCRIPTION
The `protocol` variable is set earlier in the code to `"https://"` or `"http://"`, depending on whether SSL is being used. Adding two more slashes results in `"https:////address"` and causes issues on some machines, so this removes the extra slashes :smile: