### PR TITLE
Add support for credentials requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ This will install `http-server` globally so that it may be run from the command 
 
 `--cors` Enable CORS via the `Access-Control-Allow-Origin` header
 
+`--credentials` Cookie credentials can be transferred as part of a CORS request (enables --cors automatically)
+
 `-o` Open browser window after starting the server
 
 `-c` Set cache time (in seconds) for cache-control max-age header, e.g. -c10 for 10 seconds (defaults to '3600'). To disable caching, use -c-1.

--- a/bin/http-server
+++ b/bin/http-server
@@ -9,6 +9,7 @@ var colors     = require('colors/safe'),
     opener     = require('opener'),
     argv       = require('optimist')
       .boolean('cors')
+      .boolean('credentials')
       .argv;
 
 var ifaces = os.networkInterfaces();
@@ -27,6 +28,8 @@ if (argv.h || argv.help) {
     '  -s --silent  Suppress log messages from output',
     '  --cors[=headers]   Enable CORS via the "Access-Control-Allow-Origin" header',
     '                     Optionally provide CORS headers list separated by commas',
+    '  --credentials      Cookie credentials can be transferred as part of a CORS request',
+    '                     Enables --cors automatically',
     '  -o [path]    Open browser window after starting the server',
     '  -c           Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.',
     '               To disable caching, use -c-1.',
@@ -111,6 +114,10 @@ function listen(port) {
     if (typeof argv.cors === 'string') {
       options.corsHeaders = argv.cors;
     }
+  }
+
+  if (argv.credentials) {
+    options.credentials = true;
   }
 
   if (ssl) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -66,16 +66,24 @@ function HttpServer(options) {
     res.emit('next');
   });
 
-  if (options.cors) {
+  if (options.cors || options.credentials) {
     this.headers['Access-Control-Allow-Origin'] = '*';
     this.headers['Access-Control-Allow-Headers'] = 'Origin, X-Requested-With, Content-Type, Accept, Range';
     if (options.corsHeaders) {
       options.corsHeaders.split(/\s*,\s*/)
           .forEach(function (h) { this.headers['Access-Control-Allow-Headers'] += ', ' + h; }, this);
     }
-    before.push(corser.create(options.corsHeaders ? {
+
+    var corserOptions = options.corsHeaders ? {
       requestHeaders: this.headers['Access-Control-Allow-Headers'].split(/\s*,\s*/)
-    } : null));
+    } : {};
+
+    if (options.credentials) {
+      corserOptions.supportsCredentials = true;
+      this.headers['Access-Control-Allow-Credentials'] = 'true';
+    }
+
+    before.push(corser.create(corserOptions));
   }
 
   if (options.robots) {

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -152,6 +152,43 @@ vows.describe('http-server').addBatch({
       },
       'response Access-Control-Allow-Headers should contain X-Test': function (err, res) {
         assert.ok(res.headers['access-control-allow-headers'].split(/\s*,\s*/g).indexOf('X-Test') >= 0, 204);
+      },
+      'response Access-Control-Allow-Credentials should not be presented': function (err, res) {
+        assert.equal(res.headers['access-control-allow-credentials'], undefined);
+      }
+    }
+  },
+  'When credentials is enabled': {
+    topic: function () {
+      var server = httpServer.createServer({
+        root: root,
+        credentials: true,
+        corsHeaders: 'X-Test'
+      });
+      server.listen(8083);
+      this.callback(null, server);
+    },
+    'and given OPTIONS request': {
+      topic: function () {
+        request({
+          method: 'OPTIONS',
+          uri: 'http://127.0.0.1:8083/',
+          headers: {
+            'Access-Control-Request-Method': 'GET',
+            Origin: 'http://example.com',
+            'Access-Control-Request-Headers': 'Foobar',
+            Cookie: 'cookie'
+          }
+        }, this.callback);
+      },
+      'status code should be 204': function (err, res) {
+        assert.equal(res.statusCode, 204);
+      },
+      'response Access-Control-Allow-Headers should contain X-Test': function (err, res) {
+        assert.ok(res.headers['access-control-allow-headers'].split(/\s*,\s*/g).indexOf('X-Test') >= 0, 204);
+      },
+      'response Access-Control-Allow-Credentials should be true': function (err, res) {
+        assert.equal(res.headers['access-control-allow-credentials'], 'true');
       }
     }
   }


### PR DESCRIPTION
To serve files with credentials support cross domains we ned to not just add some headers in request, we should also change Access-Control-Allow-Origin header to Origin value from request.

I added a new flag for it, because is is different from --cors logic and may be not safe for users.