### PR TITLE
documented the url option of -o.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This will install `http-server` globally so that it may be run from the command 
 
 `--cors` Enable CORS via the `Access-Control-Allow-Origin` header
 
-`-o` Open browser window after starting the server
+`-o [url` Open browser window after starting the server. optionally provide a url e.g.: -o http://localhost:8080
 
 `-c` Set cache time (in seconds) for cache-control max-age header, e.g. -c10 for 10 seconds (defaults to '3600'). To disable caching, use -c-1.
 


### PR DESCRIPTION
The description in README.md was missing this option that apears in the -h output.
Also, by adding http:// to the example, it hints to the user that this is required in the windows shell, otherwise the url is treated as another command