### PR TITLE
Upgrade ecstatic from 3.0.0 to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "colors": "1.0.3",
     "corser": "~2.0.0",
-    "ecstatic": "^3.0.0",
+    "ecstatic": "^3.2.0",
     "http-proxy": "^1.8.1",
     "opener": "~1.4.0",
     "optimist": "0.6.x",


### PR DESCRIPTION
Ecstatic 3.2.0 uses a newer version of 'mime' and thus provides support
for javascript modules (.mjs) files to be served with the approppriate
content-type.

ES6 import statements work in the browser only if the server responds
with 'application/javascript' content type.