### PR TITLE
Prevent vows from swallowing test errors on uncaught errors within topics

### DIFF
--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -5,6 +5,9 @@ var assert = require('assert'),
     request = require('request'),
     httpServer = require('../lib/http-server');
 
+// Prevent vows from swallowing errors
+process.on('uncaughtException', console.error);
+
 var root = path.join(__dirname, 'fixtures', 'root');
 
 vows.describe('http-server').addBatch({


### PR DESCRIPTION
Hello, been looking around at making some further contributions, and came across an issue where vows would swallow errors, making it very difficult to debug.  Very simple one liner (with a comment to explain its purpose).

What was a fairly simple issue (I had a process listening on 8081 that I'd forgotten about), prevented my tests from passing, with no meaningfully related error output.  This cost me a little over an hour of troubleshooting, until I was able to find the magic `uncaughtException` event, which clearly spelled out the problem.  Hoping to contribute back to help the next person!

Validating the behavior difference is fairly simple, just start an http-server on 8081 before executing tests on master vs this branch.

Cheers!