### PR TITLE
johnstonmatt/--port

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This will install `http-server` globally so that it may be run from the command 
 
 ## Available Options:
 
-`-p` Port to use (defaults to 8080)
+`-p` or `--port` Port to use (defaults to 8080)
 
 `-a` Address to use (defaults to 0.0.0.0)
 

--- a/bin/http-server
+++ b/bin/http-server
@@ -18,7 +18,7 @@ if (argv.h || argv.help) {
     'usage: http-server [path] [options]',
     '',
     'options:',
-    '  -p           Port to use [8080]',
+    '  -p --port    Port to use [8080]',
     '  -a           Address to use [0.0.0.0]',
     '  -d           Show directory listings [true]',
     '  -i           Display autoIndex [true]',
@@ -45,7 +45,7 @@ if (argv.h || argv.help) {
   process.exit();
 }
 
-var port = argv.p || parseInt(process.env.PORT, 10),
+var port = argv.p || argv.port || parseInt(process.env.PORT, 10),
     host = argv.a || '0.0.0.0',
     ssl = !!argv.S || !!argv.ssl,
     proxy = argv.P || argv.proxy,


### PR DESCRIPTION
I added the ability to use a long form of port, `--port` as it is backwards compatible, makes the api more discoverable and declaritive. See #466.