### PR TITLE
Handle proxy errors

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -111,6 +111,13 @@ function HttpServer(options) {
       proxy.web(req, res, {
         target: options.proxy,
         changeOrigin: true
+      }, function (err, req, res, target) {
+        if (options.logFn) {
+          options.logFn(req, res, {
+            message: err.message,
+            status: res.statusCode });
+        }
+        res.emit('next');
       });
     });
   }


### PR DESCRIPTION
`http-proxy` does not handle errors by default and would just throw crashing the server. This PR adds error handling with rudimental logging.