### PR TITLE
add option for client IP logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Using `npx` you can run the script without installing it first:
 
 `-U` or `--utc` Use UTC time format in log messages.
 
+`--log-ip` Enable logging of the client's IP address (default: `false`).
+
 `-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
 
 `-S` or `--ssl` Enable https.

--- a/bin/http-server
+++ b/bin/http-server
@@ -59,7 +59,7 @@ if (!argv.s && !argv.silent) {
     info: console.log,
     request: function (req, res, error) {
       var date = utc ? new Date().toUTCString() : new Date();
-      var ip = argv.log-ip
+      var ip = argv['log-ip']
           ? req.headers['x-forwarded-for'] || '' +  req.connection.remoteAddress
           : '';
       if (error) {

--- a/bin/http-server
+++ b/bin/http-server
@@ -9,6 +9,7 @@ var colors     = require('colors/safe'),
     opener     = require('opener'),
     argv       = require('optimist')
       .boolean('cors')
+      .boolean('log-ip')
       .argv;
 
 var ifaces = os.networkInterfaces();
@@ -31,6 +32,7 @@ if (argv.h || argv.help) {
     '  -c           Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.',
     '               To disable caching, use -c-1.',
     '  -U --utc     Use UTC time format in log messages.',
+    '  --log-ip     Enable logging of the client\'s IP address',
     '',
     '  -P --proxy   Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com',
     '',
@@ -57,17 +59,20 @@ if (!argv.s && !argv.silent) {
     info: console.log,
     request: function (req, res, error) {
       var date = utc ? new Date().toUTCString() : new Date();
+      var ip = argv.log-ip
+          ? req.headers['x-forwarded-for'] || '' +  req.connection.remoteAddress
+          : '';
       if (error) {
         logger.info(
-          '[%s] "%s %s" Error (%s): "%s"',
-          date, colors.red(req.method), colors.red(req.url),
+          '[%s] %s "%s %s" Error (%s): "%s"',
+          date, ip, colors.red(req.method), colors.red(req.url),
           colors.red(error.status.toString()), colors.red(error.message)
         );
       }
       else {
         logger.info(
-          '[%s] "%s %s" "%s"',
-          date, colors.cyan(req.method), colors.cyan(req.url),
+          '[%s] %s "%s %s" "%s"',
+          date, ip, colors.cyan(req.method), colors.cyan(req.url),
           req.headers['user-agent']
         );
       }


### PR DESCRIPTION
Continuing work by @paked in #187, this adds the useful feature of
logging the remote client IP address. I personally use this feature in
Apache often at work, and it would be nice to have it here as well!

The addition is the `--log-ip` option, which adds the client IP to the
log message between the date and the request method and url.

Fixes #184